### PR TITLE
Verify if it should redirect to the orders page instead of profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Verify if it should redirect to the orders page instead of profile
 
 ### Fixed
 - Add `vtex.my-orders-app` to extension points

--- a/react/components/AppRouter.js
+++ b/react/components/AppRouter.js
@@ -24,6 +24,12 @@ const AppRouter = () => {
     <Route exact key={path} path={path} component={component} />
   )
 
+  let shouldRedirectOrder = false
+
+  if(vtex) {
+    shouldRedirectOrder = vtex.orderListRendered
+  }
+
   return (
     <HashRouter>
       <Media query="(max-width: 57em)">
@@ -33,6 +39,7 @@ const AppRouter = () => {
               <Switch>
                 <Route exact path="/" component={Menu} />
                 {routes.map(toRouteComponent)}
+                <Redirect exact from="/" to={ shouldRedirectOrder ? "/orders" : "/profile"} />
                 <ExtensionPoint id="routes" />
               </Switch>
             </main>
@@ -42,7 +49,7 @@ const AppRouter = () => {
               <main className="flex-auto pt5">
                 <Switch>
                   {routes.map(toRouteComponent)}
-                  <Redirect exact from="/" to="/profile" />
+                  <Redirect exact from="/" to={ shouldRedirectOrder ? "/orders" : "/profile"} />
                   <ExtensionPoint id="routes" />
                 </Switch>
               </main>


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add verification to choose witch tab should be displayed

#### What problem is this solving?
On the legacy route `/Account/Orders` the account tab was being displayed instead of the orders

#### How should this be manually tested?
[workspace](https://recorrenciaqa.vtexcommercebeta.com.br/_secure/Account/Orders?workspace=felipe)

#### Screenshots or example usage
- Before
![image](https://user-images.githubusercontent.com/3926634/47163413-49e97c80-d2cc-11e8-93b4-05fb62c02d45.png)

- After
![image](https://user-images.githubusercontent.com/3926634/47163367-350ce900-d2cc-11e8-9c46-bf5af31535ae.png)


#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.