### PR TITLE
Fix not updating the profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Not editing profile because the email was not being sent to the `updateProfile` mutation.
 
 ## [0.16.9] - 2018-10-24
 ### Fixed

--- a/react/components/Profile/ProfileFormBox.js
+++ b/react/components/Profile/ProfileFormBox.js
@@ -71,8 +71,7 @@ class ProfileFormBox extends Component {
   submit = () => {
     const { updateProfile } = this.props
     const { profile: profileInput } = this.state
-    const { email, ...profile } = profileInput
-    return updateProfile({ variables: { profile } })
+    return updateProfile({ variables: { profile: profileInput } })
   }
 
   render() {

--- a/react/components/pages/ProfileEdit.js
+++ b/react/components/pages/ProfileEdit.js
@@ -17,7 +17,7 @@ class ProfileEdit extends Component {
 
   render() {
     const { profile } = this.props
-
+    
     return (
       <PageTemplate 
         header={<ProfileEditHeader />}


### PR DESCRIPTION
#### What is the purpose of this pull request?
It was not able to update the profile because the email was not being sent to the updateProfile mutation.

#### What problem is this solving?
![captura de tela de 2018-11-01 09-40-46](https://user-images.githubusercontent.com/12852518/47852448-8cc24e80-ddba-11e8-9b50-987eac3c3180.png)

#### How should this be manually tested?
[Click here to access the workspace.](https://waza2--storecomponents.myvtex.com/) To test it, go to the account page and try to update the profile informations.

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
