### PR TITLE
Add required prop addressQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.23.1] - 2019-02-25
+
 ### Fixed
 - Add missing required prop, resulting in a error in address form
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Add missing required prop, resulting in a error in address form
+
 ## [0.23.0] - 2019-02-12
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "my-account",
   "vendor": "vtex",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "title": "My Account",
   "description": "",
   "mustUpdateAt": "2019-07-09",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.23.0",
+  "version": "0.23.1",
   "scripts": {
     "lint:locales": "intl-equalizer"
   },

--- a/react/components/Addresses/AddressFormBox.js
+++ b/react/components/Addresses/AddressFormBox.js
@@ -33,6 +33,7 @@ class AddressFormBox extends Component {
 
     return {
       ...addr,
+      addressQuery: '',
       receiverName: addr.receiverName || defaultReceiver,
     }
   }


### PR DESCRIPTION

#### What is the purpose of this pull request?

This fixes an error inside address-form accessing `geolocationAutocompleted` of undefined. The undefined value was the missing required prop `addressQuery`.

#### What problem is this solving?


#### How should this be manually tested?

Open an address form.

#### Screenshots or example usage


#### Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)