### PR TITLE
Fix logout modal title french translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Logout modal title french translation.
+
 ## [0.27.1] - 2019-05-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.27.2] - 2019-05-20
+
 ### Fixed
 
 - Logout modal title french translation.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "my-account",
   "vendor": "vtex",
-  "version": "0.27.1",
+  "version": "0.27.2",
   "title": "My Account",
   "description": "",
   "mustUpdateAt": "2019-07-09",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.27.1",
+  "version": "0.27.2",
   "devDependencies": {
     "@types/exenv": "^1.2.0",
     "@vtex/intl-equalizer": "^2.0.1",

--- a/react/locales/fr.json
+++ b/react/locales/fr.json
@@ -8,7 +8,7 @@
   "pages.myAccount": "Mon compte",
   "pages.logout": "Sortie",
   "logoutModal.cancel": "Annuler",
-  "logoutModal.title": "Veux-tu vraiment arrêter de fumer?",
+  "logoutModal.title": "Tu veux sortir?",
   "personalData.redefinePassword": "Redéfinir mot de passe",
   "personalData.saveData": "Sauvegarder les modifications",
   "personalData.password": "Mot de passe",


### PR DESCRIPTION
#### What is the purpose of this pull request?

Title is self-explanatory.

#### What problem is this solving?

French translation for the logout modal title was not correct.

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
