### PR TITLE
Fix base href attribute deletion to check if there is a base tag before

### DIFF
--- a/react/components/AppRouter.js
+++ b/react/components/AppRouter.js
@@ -24,14 +24,18 @@ class AppRouter extends Component {
     // Possible fix, use this version of `history`:
     // https://github.com/ReactTraining/history/pull/578
     this.baseElement = document.querySelector('base')
-    this.baseHref = this.baseElement.href
-    this.baseElement.removeAttribute('href')
+    if (this.baseElement) {
+      this.baseHref = this.baseElement.href
+      this.baseElement.removeAttribute('href')
+    }
   }
 
   handleDefaultPath = path => {
     this.setState({ defaultPath: path }, () => {
       // From the workaround above
-      this.baseElement.setAttribute('href', this.baseHref)
+      if (this.baseElement) {
+        this.baseElement.setAttribute('href', this.baseHref)
+      }
     })
   }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

Check if exists a base HTML tag before doing any actions with it.

#### What problem is this solving?

If there wasn't a base tag, the deleteAttribute method would explod when trying to access undefined.

#### How should this be manually tested?

Go to the following workspace and check if My Account is not breaking.

https://www.cobasi.com.br/_secure/account/?workspace=arthur#/cards

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
