### PR TITLE
Fix typos in FormattedMessage and intl.formatMessage id param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Typos in props being passed to **FormattedMessage** component and `intl.formatMessage` function.
+
 ## [0.27.6] - 2019-07-06
 
+### Fixed
+
+- Edge case for when there is no base tag in AppRouter.
+
 ## [0.27.5] - 2019-07-06
+
+### Added
+
+- HTML base tag handling in AppRouter.
 
 ## [0.27.4] - 2019-06-17
 

--- a/react/components/Menu/ProfilePicture/PictureUploader.js
+++ b/react/components/Menu/ProfilePicture/PictureUploader.js
@@ -95,7 +95,7 @@ class PictureUploader extends Component {
                     <div className="flex w-100 items-center mb6">
                       <div className="flex-auto bt b--muted-4" />
                       <span className="mh3 c-muted-1">
-                        <FormattedMessage if="upload.or" />
+                        <FormattedMessage id="upload.or" />
                       </span>
                       <div className="flex-auto bt b--muted-4" />
                     </div>

--- a/react/components/Profile/PasswordFormBox.js
+++ b/react/components/Profile/PasswordFormBox.js
@@ -160,9 +160,7 @@ class PasswordFormBox extends Component {
                       onChange={e => this.handleChange(e, setNewPassword)}
                       onBlur={this.handleTouchField}
                       type="password"
-                      label={intl.formatMessage({
-                        id: messages.newPassword,
-                      })}
+                      label={intl.formatMessage(messages.newPassword)}
                     />
                   </div>
                   <div className="mb7">

--- a/react/components/Profile/PasswordValidator.js
+++ b/react/components/Profile/PasswordValidator.js
@@ -56,7 +56,7 @@ class PasswordValidator extends Component {
         <div className="flex mb5">
           <div className="w-50 flex items-center">
             {getIcon(has8chars)}
-            <FormattedMessage id="personalData.8chars" />
+            <FormattedMessage id="personalData.8chars" />
           </div>
           <div className="w-50 flex items-center">
             {getIcon(hasLow)}

--- a/react/components/pages/Profile.js
+++ b/react/components/pages/Profile.js
@@ -41,7 +41,9 @@ class Profile extends Component {
   }
 
   handleFinishEditingPassword = () => {
-    this.setState({ isEditingPassword: false, showToast: true }, () => this.props.data.refetch())
+    this.setState({ isEditingPassword: false, showToast: true }, () =>
+      this.props.data.refetch()
+    )
   }
 
   render() {
@@ -57,9 +59,10 @@ class Profile extends Component {
             </div>
             <div className="w-40-ns w-100-s">
               {isEditingPassword ? (
-                <AuthState email={profile.email} >
-                  {(<AuthState.Token>
-                    {({value, setValue}) => (
+                <AuthState email={profile.email}>
+                  {
+                    <AuthState.Token>
+                      {({ value, setValue }) => (
                         <PasswordFormBox
                           email={profile.email}
                           passwordLastUpdate={profile.passwordLastUpdate}
@@ -67,14 +70,15 @@ class Profile extends Component {
                           currentToken={value}
                           setToken={setValue}
                         />
-                      )
-                    }
-                  </AuthState.Token>)}
+                      )}
+                    </AuthState.Token>
+                  }
                 </AuthState>
               ) : (
                 <PasswordBox
                   passwordLastUpdate={profile.passwordLastUpdate}
-                  onEditClick={this.handleEditingPassword} />
+                  onEditClick={this.handleEditingPassword}
+                />
               )}
             </div>
             {showToast && (


### PR DESCRIPTION
#### What is the purpose of this pull request?

Corrected some typos when passing props to formatMessage functions.

#### What problem is this solving?

Because of the typos, required props were undefined and exceptions were thrown.

#### How should this be manually tested?

Use the following workspace and try to upload a profile picture or edit your password.

https://arthur--recorrenciaqa.myvtex.com/account#/profile

#### Screenshots or example usage

* before
<img width="1540" alt="Screen Shot 2019-07-09 at 18 27 53" src="https://user-images.githubusercontent.com/11592617/60924353-6755e080-a277-11e9-9125-c7053a87e134.png">
<img width="1344" alt="Screen Shot 2019-07-09 at 18 28 15" src="https://user-images.githubusercontent.com/11592617/60924360-6ae96780-a277-11e9-8960-6dccccb1835b.png">

* after

<img width="486" alt="Screen Shot 2019-07-09 at 18 24 33" src="https://user-images.githubusercontent.com/11592617/60924174-ebf42f00-a276-11e9-9158-7fafd88ec32d.png">
<img width="595" alt="Screen Shot 2019-07-09 at 18 24 44" src="https://user-images.githubusercontent.com/11592617/60924180-ed255c00-a276-11e9-8b24-600cb78e00cf.png">


#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
