### PR TITLE
Fix/profile toast text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fix
+
+- Toast content not being correctly localized.
+
 ## [0.27.7] - 2019-07-10
 
 ### Fixed

--- a/react/components/shared/Toast.js
+++ b/react/components/shared/Toast.js
@@ -32,7 +32,7 @@ class Toast extends Component {
           isClosing ? 'fadeOutDown' : 'fadeInUp'
         }  slower bottom--1 fixed z-5 ma7-ns mb5-s left-2-ns w-100-s w-30-ns`}>
         <Alert type="success" onClose={onClose}>
-          <FormattedMessage id="messageId" />
+          <FormattedMessage id={messageId} />
         </Alert>
       </div>
     )


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix the toast localized message when a user edit its information:

![image](https://user-images.githubusercontent.com/12702016/61057174-1e16a580-a3cb-11e9-8ab9-dde09b6c9c16.png)

Clubhouse story: https://app.clubhouse.io/vtex-dev/story/14996/tradu%C3%A7ao-da-mensagem-no-update-do-form-de-dados-do-my-account

#### How should this be manually tested?

1) goto https://kiwi--recorrenciaqa.myvtex.com/account#/profile?success=true
2) log in and edit your information
3) check if the toast content is localized instead of displaying `messageId`

#### Screenshots or example usage

**Before:**
![image](https://user-images.githubusercontent.com/12702016/61057174-1e16a580-a3cb-11e9-8ab9-dde09b6c9c16.png)

**After:**
![image](https://user-images.githubusercontent.com/12702016/61057258-469e9f80-a3cb-11e9-9e1d-1194d113d42b.png)


#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
