### PR TITLE
Fix/geolocation input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- GeolocationInput to automatically appear when store configurations are settled.
+
 ## [0.27.8] - 2019-07-11
 
 ### Fix

--- a/react/components/Addresses/AddressEditor.js
+++ b/react/components/Addresses/AddressEditor.js
@@ -10,10 +10,8 @@ import {
   PostalCodeGetter,
   AddressForm,
   AutoCompletedFields,
-  AddressRules,
   AddressSubmitter,
   GoogleMapsContainer,
-  Map,
 } from 'vtex.address-form/components'
 import { StyleguideInput, GeolocationInput } from 'vtex.address-form/inputs'
 import { AddressShape } from 'vtex.address-form/shapes'
@@ -73,6 +71,8 @@ class AddressEditor extends Component {
       ? address.postalCode.valid && !address.postalCode.geolocationAutoCompleted
       : address.postalCode.value !== null
 
+    debugger
+
     const hasAutoCompletedFields = Object.keys(address).some(
       fieldName =>
         (address && address[fieldName].geolocationAutoCompleted) ||
@@ -93,7 +93,7 @@ class AddressEditor extends Component {
         address={address}
         Input={StyleguideInput}
         onChangeAddress={this.handleAddressChange}
-        rules={rules.geolocation}
+        rules={mapsAPIKey && rules.geolocation}
         autoCompletePostalCode>
         <Fragment>
           <CountrySelector shipsTo={shipCountries} />
@@ -111,9 +111,9 @@ class AddressEditor extends Component {
             </GoogleMapsContainer>
           )}
 
-          {/* {!validGeoCoords && !mapsAPIKey && <PostalCodeGetter />} */}
+          {!validGeoCoords && !mapsAPIKey && <PostalCodeGetter />}
 
-          {hasAutoCompletedFields && !mapsAPIKey && (
+          {hasAutoCompletedFields && (
             <div className="pb7">
               <AutoCompletedFields>
                 <a className="c-link pointer">
@@ -123,7 +123,13 @@ class AddressEditor extends Component {
             </div>
           )}
 
-          {/* {(validGeoCoords || validPostalCode) && <AddressForm />} */}
+          {(validGeoCoords ||
+            validPostalCode ||
+            (rules.geolocation &&
+              rules.geolocation.postalCode &&
+              !rules.geolocation.postalCode.isRequired)) && (
+            <AddressForm rules={mapsAPIKey && rules.geolocation} />
+          )}
 
           <AddressSubmitter onSubmit={onSubmit} rules={rules.geolocation}>
             {handleSubmit => (

--- a/react/components/Addresses/AddressEditor.js
+++ b/react/components/Addresses/AddressEditor.js
@@ -71,8 +71,6 @@ class AddressEditor extends Component {
       ? address.postalCode.valid && !address.postalCode.geolocationAutoCompleted
       : address.postalCode.value !== null
 
-    debugger
-
     const hasAutoCompletedFields = Object.keys(address).some(
       fieldName =>
         (address && address[fieldName].geolocationAutoCompleted) ||
@@ -111,7 +109,7 @@ class AddressEditor extends Component {
             </GoogleMapsContainer>
           )}
 
-          {!validGeoCoords && !mapsAPIKey && <PostalCodeGetter />}
+          {!validGeoCoords && <PostalCodeGetter />}
 
           {hasAutoCompletedFields && (
             <div className="pb7">
@@ -123,12 +121,14 @@ class AddressEditor extends Component {
             </div>
           )}
 
-          {(validGeoCoords ||
-            validPostalCode ||
-            (rules.geolocation &&
-              rules.geolocation.postalCode &&
-              !rules.geolocation.postalCode.isRequired)) && (
-            <AddressForm rules={mapsAPIKey && rules.geolocation} />
+          {(validGeoCoords || validPostalCode || !isNew) && (
+            <AddressForm
+              address={address}
+              onChangeAddress={this.handleAddressChange}
+              notApplicableLabel={intl.formatMessage({
+                id: 'addresses.notApplicable',
+              })}
+            />
           )}
 
           <AddressSubmitter onSubmit={onSubmit} rules={rules.geolocation}>
@@ -138,7 +138,7 @@ class AddressEditor extends Component {
                 block
                 size="small"
                 isLoading={isLoading}
-                disabled={!(validGeoCoords || validPostalCode)}>
+                disabled={!(validGeoCoords || validPostalCode || !isNew)}>
                 <FormattedMessage id={intlId} />
               </Button>
             )}

--- a/react/components/Addresses/AddressEditor.js
+++ b/react/components/Addresses/AddressEditor.js
@@ -131,6 +131,7 @@ class AddressEditor extends Component {
           {(validGeoCoords || validPostalCode || !isNew) && (
             <AddressForm
               address={address}
+              Input={StyleguideInput}
               onChangeAddress={this.handleAddressChange}
               notApplicableLabel={intl.formatMessage({
                 id: 'addresses.notApplicable',

--- a/react/components/Addresses/AddressEditor.js
+++ b/react/components/Addresses/AddressEditor.js
@@ -12,6 +12,7 @@ import {
   AutoCompletedFields,
   AddressSubmitter,
   GoogleMapsContainer,
+  Map,
 } from 'vtex.address-form/components'
 import { StyleguideInput, GeolocationInput } from 'vtex.address-form/inputs'
 import { AddressShape } from 'vtex.address-form/shapes'
@@ -25,18 +26,14 @@ class AddressEditor extends Component {
     super(props)
 
     this.state = {
-      address: {
-        ...addValidation(props.address),
-      },
+      address: addValidation(props.address),
     }
   }
 
   componentDidMount() {
     const { address } = this.props
     this.setState({
-      address: {
-        ...addValidation(address),
-      },
+      address: addValidation(address),
     })
   }
 
@@ -104,6 +101,16 @@ class AddressEditor extends Component {
                     loadingGoogle={loading}
                     googleMaps={googleMaps}
                   />
+
+                  {validGeoCoords && (
+                    <Map
+                      loadingGoogle={loading}
+                      googleMaps={googleMaps}
+                      mapProps={{
+                        className: 'mb7 br2 h4',
+                      }}
+                    />
+                  )}
                 </Fragment>
               )}
             </GoogleMapsContainer>

--- a/react/components/Addresses/AddressFormBox.js
+++ b/react/components/Addresses/AddressFormBox.js
@@ -97,8 +97,6 @@ class AddressFormBox extends Component {
         shipsTo && shipsTo.length > 0 ? shipsTo[0] : baseAddress.country.value,
     }
 
-    const isLoading = false
-
     const country =
       shipsTo && shipsTo.length > 0 ? shipsTo[0] : address.country.value
 
@@ -108,7 +106,7 @@ class AddressFormBox extends Component {
           <AddressEditor
             address={address}
             isNew={isNew}
-            isLoading={isLoading}
+            isLoading={this.state.isLoading}
             onSubmit={this.handleSubmit}
             shipsTo={shipsTo}
           />

--- a/react/components/Addresses/AddressFormBox.js
+++ b/react/components/Addresses/AddressFormBox.js
@@ -5,7 +5,7 @@ import { compose } from 'recompose'
 import { AddressShape } from 'vtex.address-form/shapes'
 import { AddressRules } from 'vtex.address-form/components'
 import ContentBox from '../shared/ContentBox'
-import emptyAddress from './emptyAddress'
+import getEmptyAddress from './emptyAddress'
 import AddressEditor from './AddressEditor'
 import AddressDeleter from './AddressDeleter'
 import CREATE_ADDRESS from '../../graphql/createAddress.gql'
@@ -86,6 +86,9 @@ class AddressFormBox extends Component {
 
   render() {
     const { onAddressDeleted, isNew, shipsTo, onError } = this.props
+    const country =
+      shipsTo && shipsTo.length > 0 ? shipsTo[0] : address.country.value
+    const emptyAddress = getEmptyAddress(country)
     const baseAddress = isNew ? emptyAddress : this.props.address
 
     if (!baseAddress) return null
@@ -95,9 +98,6 @@ class AddressFormBox extends Component {
       country:
         shipsTo && shipsTo.length > 0 ? shipsTo[0] : baseAddress.country.value,
     }
-
-    const country =
-      shipsTo && shipsTo.length > 0 ? shipsTo[0] : address.country.value
 
     return (
       <ContentBox shouldAllowGrowing maxWidthStep={6}>

--- a/react/components/Addresses/AddressFormBox.js
+++ b/react/components/Addresses/AddressFormBox.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import { graphql } from 'react-apollo'
 import { compose } from 'recompose'
 import { AddressShape } from 'vtex.address-form/shapes'
+import { AddressRules } from 'vtex.address-form/components'
 import ContentBox from '../shared/ContentBox'
 import emptyAddress from './emptyAddress'
 import AddressEditor from './AddressEditor'
@@ -54,6 +55,7 @@ class AddressFormBox extends Component {
   }
 
   handleSubmit = (valid, address) => {
+    debugger
     if (!valid) return
 
     const {
@@ -89,19 +91,28 @@ class AddressFormBox extends Component {
 
     if (!baseAddress) return null
 
-    const address = this.prepareAddress(baseAddress)
+    const address = {
+      ...this.prepareAddress(baseAddress),
+      country:
+        shipsTo && shipsTo.length > 0 ? shipsTo[0] : baseAddress.country.value,
+    }
 
     const isLoading = false
 
+    const country =
+      shipsTo && shipsTo.length > 0 ? shipsTo[0] : address.country.value
+
     return (
       <ContentBox shouldAllowGrowing maxWidthStep={6}>
-        <AddressEditor
-          address={address}
-          isNew={isNew}
-          isLoading={isLoading}
-          onSubmit={this.handleSubmit}
-          shipsTo={shipsTo}
-        />
+        <AddressRules country={country} shouldUseIOFetching>
+          <AddressEditor
+            address={address}
+            isNew={isNew}
+            isLoading={isLoading}
+            onSubmit={this.handleSubmit}
+            shipsTo={shipsTo}
+          />
+        </AddressRules>
         {!isNew && (
           <AddressDeleter
             addressId={address.addressId}

--- a/react/components/Addresses/AddressFormBox.js
+++ b/react/components/Addresses/AddressFormBox.js
@@ -55,7 +55,6 @@ class AddressFormBox extends Component {
   }
 
   handleSubmit = (valid, address) => {
-    debugger
     if (!valid) return
 
     const {

--- a/react/components/Addresses/AddressFormBox.js
+++ b/react/components/Addresses/AddressFormBox.js
@@ -95,8 +95,7 @@ class AddressFormBox extends Component {
 
     const address = {
       ...this.prepareAddress(baseAddress),
-      country:
-        shipsTo && shipsTo.length > 0 ? shipsTo[0] : baseAddress.country.value,
+      country: country,
     }
 
     return (

--- a/react/components/Addresses/emptyAddress.js
+++ b/react/components/Addresses/emptyAddress.js
@@ -3,7 +3,7 @@ export default {
   addressType: 'residential',
   city: null,
   complement: null,
-  country: 'BRA',
+  country: 'ROU',
   geoCoordinates: [],
   neighborhood: null,
   number: null,

--- a/react/components/Addresses/emptyAddress.js
+++ b/react/components/Addresses/emptyAddress.js
@@ -1,16 +1,18 @@
-export default {
-  addressId: '0',
-  addressType: 'residential',
-  city: null,
-  complement: null,
-  country: 'ROU',
-  geoCoordinates: [],
-  neighborhood: null,
-  number: null,
-  postalCode: null,
-  receiverName: null,
-  reference: null,
-  state: null,
-  street: null,
-  addressQuery: null,
+export default function getEmptyAddress(country) {
+  return {
+    addressId: '0',
+    addressType: 'residential',
+    city: null,
+    complement: null,
+    country: country,
+    geoCoordinates: [],
+    neighborhood: null,
+    number: null,
+    postalCode: null,
+    receiverName: null,
+    reference: null,
+    state: null,
+    street: null,
+    addressQuery: null,
+  }
 }

--- a/react/graphql/getStoreConfigs.gql
+++ b/react/graphql/getStoreConfigs.gql
@@ -1,4 +1,4 @@
-query StoreConfigs @context(scope: "private") {
+query StoreConfigs @context(provider: "vtex.store-graphql") {
   storeConfigs {
     googleMapsApiKey
   }

--- a/react/graphql/getStoreConfigs.gql
+++ b/react/graphql/getStoreConfigs.gql
@@ -1,0 +1,5 @@
+query StoreConfigs @context(scope: "private") {
+  storeConfigs {
+    googleMapsApiKey
+  }
+}

--- a/react/locales/ca.json
+++ b/react/locales/ca.json
@@ -41,6 +41,7 @@
   "addresses.saveAddress": "Guardar adreça",
   "addresses.deleteAddress": "Esborrar adreça",
   "addresses.notFound": "No tens cap adreça guardada",
+  "addresses.notApplicable": "S/N",
   "commons.edit": "Editar",
   "alert.addressNotFound": "L'adreça seleccionada no s'ha trobat.",
   "alert.success": "La seva informació s'ha guardat amb èxit.",

--- a/react/locales/en.json
+++ b/react/locales/en.json
@@ -41,6 +41,7 @@
   "addresses.saveAddress": "Save address",
   "addresses.deleteAddress": "Delete address",
   "addresses.notFound": "You don't have any addresses yet!",
+  "addresses.notApplicable": "N/A",
   "commons.edit": "Edit",
   "alert.addressNotFound": "The selected address was not found.",
   "alert.success": "Your information was successfully saved.",

--- a/react/locales/es.json
+++ b/react/locales/es.json
@@ -41,6 +41,7 @@
   "addresses.saveAddress": "Guardar dirección",
   "addresses.deleteAddress": "Borrar dirección",
   "addresses.notFound": "Usted no tiene ninguna de las direcciones registrado.",
+  "addresses.notApplicable": "S/N",
   "commons.edit": "Editar",
   "alert.addressNotFound": "La dirección seleccionada no fue encontrada.",
   "alert.success": "Su información se guardó con éxito.",

--- a/react/locales/fr.json
+++ b/react/locales/fr.json
@@ -41,6 +41,7 @@
   "addresses.saveAddress": "Sauvegarder addresse",
   "addresses.deleteAddress": "Supprimer addresse",
   "addresses.notFound": "Vous n'avez aucune adresse enregistré !",
+  "addresses.notApplicable": "S/N",
   "commons.edit": "Modifier",
   "alert.addressNotFound": "L'adresse sélectionnée n'a pas été trouvée.",
   "alert.success": "Vos informations ont été enregistrées avec succès.",

--- a/react/locales/it.json
+++ b/react/locales/it.json
@@ -45,6 +45,7 @@
   "addresses.saveAddress": "Salva l'indirizzo",
   "addresses.deleteAddress": "Elimina l'indirizzo",
   "addresses.notFound": "Non hai ancora nessun indirizzo!",
+  "addresses.notApplicable": "N/N",
 
   "commons.edit": "Modifica",
 

--- a/react/locales/pt.json
+++ b/react/locales/pt.json
@@ -41,6 +41,7 @@
   "addresses.saveAddress": "Salvar endereço",
   "addresses.deleteAddress": "Remover endereço",
   "addresses.notFound": "Você não tem nenhum endereço cadastrado!",
+  "addresses.notApplicable": "S/N",
   "commons.edit": "Editar",
   "alert.addressNotFound": "O endereço especificado não foi encontrado.",
   "alert.success": "Suas informações foram salvas com sucesso.",

--- a/react/locales/ro.json
+++ b/react/locales/ro.json
@@ -41,6 +41,7 @@
   "addresses.saveAddress": "Salvați adresa",
   "addresses.deleteAddress": "Ștergeți adresa",
   "addresses.notFound": "Încă nu aveți adrese!",
+  "addresses.notApplicable": "N/A",
   "commons.edit": "Editați",
   "alert.addressNotFound": "Adresa selectată nu a fost găsită.",
   "alert.success": "Informațiile dvs. au fost salvate cu succes.",


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix the geolocation input in the my account by using the store configuration that comes from the portal v2 API. Besides, there are some improvements in loading state behavior and refactoring.

#### What problem is this solving?

The user needed to set the geolocation input manually using the admin app settings section.

#### How should this be manually tested?

Use the following workspace and create an address using the geolocation input(image 1).

https://www.f64.ro/_secure/account?workspace=arthur#/addresses?success=true

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/11592617/61242033-1f253b00-a71b-11e9-8111-028f27485a1a.png)

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
