### PR TITLE
Fix/geolocation input condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- GeolocationInput to be rendered based on geolocation flag
+- GeolocationInput to be rendered based on geolocation flag.
 
 ## [0.27.9] - 2019-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- GeolocationInput to be rendered based on geolocation flag
+
 ## [0.27.9] - 2019-07-16
 
 ### Fixed
@@ -15,7 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.27.8] - 2019-07-11
 
-### Fix
+### Fixed
 
 - Toast content not being correctly localized.
 
@@ -39,13 +43,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.27.4] - 2019-06-17
 
-### Fix
+### Fixed
 
 - intl.formatMessage to FormattedMessage.
 
 ## [0.27.3] - 2019-06-07
 
-### Fix
+### Fixed
 
 - Fix `country` fallback on add new address.
 

--- a/react/components/Addresses/AddressEditor.js
+++ b/react/components/Addresses/AddressEditor.js
@@ -89,7 +89,6 @@ class AddressEditor extends Component {
 
     const currentRules = isGeolocation && mapsAPIKey && rules.geolocation
 
-    debugger
     return (
       <AddressContainer
         address={address}

--- a/react/components/Addresses/AddressEditor.js
+++ b/react/components/Addresses/AddressEditor.js
@@ -78,22 +78,29 @@ class AddressEditor extends Component {
       this.props.getStoreConfigs.storeConfigs &&
       this.props.getStoreConfigs.storeConfigs.googleMapsApiKey
 
+    const isGeolocation =
+      this.props.getStoreConfigs.storeConfigs &&
+      this.props.getStoreConfigs.storeConfigs.geolocation
+
     const shipCountries = shipsTo.map(code => ({
       label: intl.formatMessage({ id: `country.${code}` }),
       value: code,
     }))
 
+    const currentRules = isGeolocation && mapsAPIKey && rules.geolocation
+
+    debugger
     return (
       <AddressContainer
         address={address}
         Input={StyleguideInput}
         onChangeAddress={this.handleAddressChange}
-        rules={mapsAPIKey && rules.geolocation}
+        rules={currentRules}
         autoCompletePostalCode>
         <Fragment>
           <CountrySelector shipsTo={shipCountries} />
 
-          {isNew && mapsAPIKey && !validPostalCode && (
+          {isNew && isGeolocation && !validPostalCode && (
             <GoogleMapsContainer apiKey={mapsAPIKey} locale={locale}>
               {({ loading, googleMaps }) => (
                 <Fragment>
@@ -139,7 +146,7 @@ class AddressEditor extends Component {
             />
           )}
 
-          <AddressSubmitter onSubmit={onSubmit} rules={rules.geolocation}>
+          <AddressSubmitter onSubmit={onSubmit} rules={currentRules}>
             {handleSubmit => (
               <Button
                 onClick={handleSubmit}

--- a/react/graphql/getStoreConfigs.gql
+++ b/react/graphql/getStoreConfigs.gql
@@ -1,5 +1,6 @@
 query StoreConfigs @context(provider: "vtex.store-graphql") {
   storeConfigs {
+    geolocation
     googleMapsApiKey
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Render the GeolocationInput component only when the `geolocation` flag is activated.

#### What problem is this solving?

Some stores may not want to use the geolocation, but they do have their google maps API key for the pick up point. So, what determinate if the geolocation should be rendered is the geolocation flag and not only the presence of the google maps key.

#### How should this be manually tested?

Using the following workspace, go to "Minha conta", then to "Endereços" and check that the geolocation input appears and autocompletes correctly.

https://vtexgame1geo.myvtex.com/_secure/Account#/addresses/new

After that, follow similar steps to arrive at the my account address view and check that the geolocation input does not appear in the following workspace: https://www.f64.ro/_secure/account?workspace=arthur#/addresses/new

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
