### PR TITLE
Add logging to Splunk for My Account URL and general errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Log in Splunk if URL that points to My Account is `/account/orders`.
-- Log if some error occurs, as a way of creating some deployment process.
+- Log whenever some error occurs so we can create some deployment analysis process.
 
 ## [0.27.13] - 2019-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Log in Splunk if URL that points to My Account is `/account/orders`.
+- Log if some error occurs, as a way of creating some deployment process.
+
 ## [0.27.13] - 2019-07-31
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Log in Splunk if URL that points to My Account is `/account/orders`.
+- Log on Splunk if the URL that points to My Account is `/account/orders`.
 - Log whenever some error occurs so we can create some deployment analysis process.
 
 ## [0.27.13] - 2019-07-31

--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
   "intl-equalizer": {
     "referenceLocale": "en",
     "localeDirectory": "react/locales/"
+  },
+  "dependencies": {
+    "splunk-events": "^1.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,5 @@
     "referenceLocale": "en",
     "localeDirectory": "react/locales/"
   },
-  "dependencies": {
-    "splunk-events": "^1.3.0"
-  }
+  "dependencies": {}
 }

--- a/react/SplunkUtils.js
+++ b/react/SplunkUtils.js
@@ -1,0 +1,30 @@
+import SplunkEvents from 'splunk-events'
+
+const splunkEvents = new SplunkEvents()
+
+splunkEvents.config({
+  endpoint: 'https://splunk-heavyforwarder-public.vtex.com:8088',
+  token: 'feee5906-39b2-43a5-bb46-b927b8e01da3',
+})
+
+export function logMyAccountURL() {
+  const { account } = window.__RUNTIME__
+  splunkEvents.logEvent('Important', 'Info', 'MyAccount', 'MyAccountURL', {
+    account: account,
+  })
+}
+
+export function logGeneralErrors(error, info) {
+  const { account } = window.__RUNTIME__
+  splunkEvents.logEvent(
+    'Critical',
+    'Error',
+    'MyAccount',
+    'MyAccountGeneralError',
+    {
+      error: JSON.stringify(error),
+      info: JSON.stringify(info),
+    },
+    account
+  )
+}

--- a/react/components/Menu/index.js
+++ b/react/components/Menu/index.js
@@ -5,11 +5,12 @@ import { ExtensionPoint } from 'render'
 
 class Menu extends Component {
   state = {
-    hasExtension: null
+    hasExtension: null,
   }
 
-  handleExtension = (hasExtension) => {
+  handleExtension = hasExtension => {
     this.setState({ hasExtension })
+    throw new Error('um erro de teste')
   }
 
   render() {

--- a/react/components/Menu/index.js
+++ b/react/components/Menu/index.js
@@ -10,7 +10,6 @@ class Menu extends Component {
 
   handleExtension = hasExtension => {
     this.setState({ hasExtension })
-    throw new Error('um erro de teste')
   }
 
   render() {

--- a/react/index.js
+++ b/react/index.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import AppRouter from './components/AppRouter'
 import ClientSide from './components/ClientSide'
 import { logMyAccountURL, logGeneralErrors } from './SplunkUtils'
+
 import 'vtex.country-codes/locales'
 import './style.global.css'
 

--- a/react/index.js
+++ b/react/index.js
@@ -1,17 +1,32 @@
-import React from 'react'
+import React, { Component } from 'react'
 import AppRouter from './components/AppRouter'
 import ClientSide from './components/ClientSide'
+import { logMyAccountURL, logGeneralErrors } from './SplunkUtils'
 import 'vtex.country-codes/locales'
 import './style.global.css'
 
-const bootstrap = () => {
-  return (
-    <div className="vtex-account helvetica flex justify-around">
-      <ClientSide>
-        <AppRouter />
-      </ClientSide>
-    </div>
-  )
+class bootstrap extends Component {
+  constructor(props) {
+    super(props)
+
+    if (window.location.href.match('/account/orders')) {
+      logMyAccountURL()
+    }
+  }
+
+  componentDidCatch(error, info) {
+    logGeneralErrors(error, info)
+  }
+
+  render() {
+    return (
+      <div className="vtex-account helvetica flex justify-around">
+        <ClientSide>
+          <AppRouter />
+        </ClientSide>
+      </div>
+    )
+  }
 }
 
 export default bootstrap

--- a/react/index.js
+++ b/react/index.js
@@ -10,13 +10,18 @@ class bootstrap extends Component {
   constructor(props) {
     super(props)
 
-    if (window.location.href.match('/account/orders')) {
+    if (
+      window.location.href.match('/account/orders') &&
+      window.__RUNTIME__.workspace === 'master'
+    ) {
       logMyAccountURL()
     }
   }
 
   componentDidCatch(error, info) {
-    logGeneralErrors(error, info)
+    if (window.__RUNTIME__.workspace === 'master') {
+      logGeneralErrors(error, info)
+    }
   }
 
   render() {

--- a/react/package.json
+++ b/react/package.json
@@ -11,7 +11,8 @@
     "react-dropzone": "^5.0.1",
     "react-intl": "^2.4.0",
     "react-media": "^1.8.0",
-    "recompose": "^0.27.1"
+    "recompose": "^0.27.1",
+    "splunk-events": "^1.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.2",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4926,6 +4926,11 @@ split-string@^3.0.1, split-string@^3.0.2:
   dependencies:
     extend-shallow "^3.0.0"
 
+splunk-events@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/splunk-events/-/splunk-events-1.3.0.tgz#8dbb6216c5b02a9cd920cfc9beb1fcd62a324b9d"
+  integrity sha512-1sxtP0FLJYZ3ZN2rqBo9EEFkLjR+iJjc+nB/BZNvQGgMIOGZkzuxSTMpVuYXwW/3IMhHlc/5NBjc1sYV17kkCg==
+
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -447,6 +447,11 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz#81c0ce8f21474756148bbb5f3bfc0f36bf15d76e"
   integrity sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==
 
+splunk-events@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/splunk-events/-/splunk-events-1.3.0.tgz#8dbb6216c5b02a9cd920cfc9beb1fcd62a324b9d"
+  integrity sha512-1sxtP0FLJYZ3ZN2rqBo9EEFkLjR+iJjc+nB/BZNvQGgMIOGZkzuxSTMpVuYXwW/3IMhHlc/5NBjc1sYV17kkCg==
+
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -447,11 +447,6 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz#81c0ce8f21474756148bbb5f3bfc0f36bf15d76e"
   integrity sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==
 
-splunk-events@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/splunk-events/-/splunk-events-1.3.0.tgz#8dbb6216c5b02a9cd920cfc9beb1fcd62a324b9d"
-  integrity sha512-1sxtP0FLJYZ3ZN2rqBo9EEFkLjR+iJjc+nB/BZNvQGgMIOGZkzuxSTMpVuYXwW/3IMhHlc/5NBjc1sYV17kkCg==
-
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"


### PR DESCRIPTION
#### What is the purpose of this pull request?

Title is self-explanatory.

#### What problem is this solving?

Log accounts that use `/account/orders` in its URL in order to map them. Besides, it adds general error logging.

#### How should this be manually tested?

go to [1] and access My Account. Then, go to [2] and check that your access was logged.

[1]: https://cobasi.myvtex.com/_secure/account/orders?workspace=arthur#/cards
[2]: https://splunk7.vtex.com/en-US/app/search/search?q=search%20index%3Dmy_account&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-5d%40d&latest=now&display.page.search.tab=events&sid=1565298680.90134_D318FDA5-14D0-4248-8853-FBCE1DBB4B96

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
