### PR TITLE
Prevent country from saved address from being overwritten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Prevent saved `country` from saved addresses from being overwritten when editing.
+
 ## [0.28.0] - 2019-08-22
 
 ### Changed

--- a/react/components/Addresses/AddressFormBox.tsx
+++ b/react/components/Addresses/AddressFormBox.tsx
@@ -91,15 +91,10 @@ class AddressFormBox extends Component<InnerProps & OutterProps> {
     const { onAddressDeleted, isNew, shipsTo, onError, runtime } = this.props
     const country =
       shipsTo && shipsTo.length > 0 ? shipsTo[0] : runtime.culture.country
-    const emptyAddress = getEmptyAddress(country)
-    const baseAddress = isNew ? emptyAddress : this.props.address
 
-    if (!baseAddress) return null
-
-    const address = {
-      ...this.prepareAddress(baseAddress),
-      country: country,
-    }
+    const address = this.prepareAddress(
+      isNew ? getEmptyAddress(country) : this.props.address
+    )
 
     return (
       <ContentBox shouldAllowGrowing maxWidthStep={6}>


### PR DESCRIPTION
#### What did you change? \*

<!--- Describe your changes in detail. -->

The `country` of every address being created/edited was being overwritten with the first country the store has shipping to or to `__RUNTIME__.culture.country`. 

#### Why? \*

For new addresses, this makes sense, but when editing a saved addressed, its saved country value should be used instead.

#### How to test it? \*

<!--- Link to a running workspace with some steps to reproduce it or even a screenshot of before/after -->

https://kiwi--beira.myvtex.com/_secure/account?workspace=kiwi#/addresses/new

Clubhouse: https://app.clubhouse.io/vtex/story/19278/pa%C3%ADs-errado-selecionado-ao-editar-um-endere%C3%A7o-j%C3%A1-salvo
Slack: https://vtex.slack.com/archives/CEZQXQJ1Y/p1567100021009800

#### Related to / Depends on?

---

#### Types of changes \*

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical improvements
  <!--- * Required -->
