### PR TITLE
Fix profile photo plus sign button size on Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Fixewd
+### Fixed
 
 - Fix profile photo plus sign button size.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixewd
+
+- Fix profile photo plus sign button size.
+
 ## [0.29.1] - 2019-09-18
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Fix profile photo plus sign button size.
+- Profile photo plus sign button size.
 
 ## [0.29.1] - 2019-09-18
 

--- a/react/components/Menu/ProfilePicture/UserPicture.tsx
+++ b/react/components/Menu/ProfilePicture/UserPicture.tsx
@@ -25,7 +25,8 @@ class UserPicture extends Component<Props> {
       <React.Fragment>
         <PictureRenderer imagePath={imagePath} />
         <button
-          className="absolute bottom-0 right-0 c-on-base--inverted center bg-action-primary br-100 f4 bn pointer"
+          className="absolute bottom-0 right-0 pa0 c-on-base--inverted bg-action-primary br-100 f4 bn pointer flex justify-center items-center"
+          style={{ lineHeight: 0, width: 26, height: 26 }}
           onClick={this.handleOpenModal}>
           +
         </button>

--- a/react/components/Menu/ProfilePicture/UserPicture.tsx
+++ b/react/components/Menu/ProfilePicture/UserPicture.tsx
@@ -25,10 +25,10 @@ class UserPicture extends Component<Props> {
       <React.Fragment>
         <PictureRenderer imagePath={imagePath} />
         <button
-          className="absolute bottom-0 right-0 pa0 c-on-base--inverted bg-action-primary br-100 f4 bn pointer flex justify-center items-center"
-          style={{ lineHeight: 0, width: 26, height: 26 }}
+          className="absolute bottom-0 right-0 pa0 c-on-base--inverted bg-action-primary br-100 f5 bn pointer flex justify-center items-center"
+          style={{ width: 26, height: 26 }}
           onClick={this.handleOpenModal}>
-          +
+          ＋
         </button>
         <Modal centered isOpen={isModalOpen} onClose={this.handleCloseModal}>
           <div className="pv4 ph4">


### PR DESCRIPTION
#### What did you change? \*

Explicitly defined the `+` button size (26px/26px), removed default browser padding (`pa0`) and centered the `+` with `flex items-center justify-center`

#### Why? \*

Safari has some default horizontal `padding` values for `<button>`s:

**Before:**
![image](https://user-images.githubusercontent.com/12702016/65912734-14d31e80-e3a5-11e9-8b04-d33305a10085.png)


**After:**
![image](https://user-images.githubusercontent.com/12702016/65912715-0c7ae380-e3a5-11e9-88b4-2e6336a35331.png)


#### How to test it? \*

Workspace to test: https://kiwi--recorrenciaqa.myvtex.com/account#/profile

#### Types of changes \*

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical improvements
  <!--- * Required -->
