### PR TITLE
Set the useGeolocation flag when using geolocation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
   "editor.formatOnSave": true,
-  "prettier.eslintIntegration": true,
   "eslint.validate": [
     {
       "language": "javascript",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Invisible postal code invalidation when editing an address.
+
 ## [0.30.0] - 2019-11-13
 
 ### Added

--- a/react/components/Addresses/AddressForm.tsx
+++ b/react/components/Addresses/AddressForm.tsx
@@ -69,14 +69,11 @@ class AddressForm extends Component<InnerProps & OuterProps, State> {
     // allow to edit only with geolocation component
     if (
       this.hasGeolocationPreference() &&
-      curAddress.postalCode &&
-      curAddress.postalCode.geolocationAutoCompleted &&
-      newAddress.postalCode &&
-      !newAddress.postalCode.geolocationAutoCompleted
+      newAddress.addressQuery &&
+      !newAddress.addressQuery.geolocationAutoCompleted
     ) {
       AUTO_COMPLETABLE_FIELDS.forEach(field => {
         newAddress[field].value = null
-        delete newAddress[field].geolocationAutoCompleted
         delete newAddress[field].valid
       })
     }
@@ -145,7 +142,10 @@ class AddressForm extends Component<InnerProps & OuterProps, State> {
     const hasAutoCompletedFields = this.hasAutoCompletedFields()
 
     return (
-      <AddressRules country={address.country.value} shouldUseIOFetching>
+      <AddressRules
+        country={address.country.value}
+        shouldUseIOFetching
+        useGeolocation={prefersGeolocation}>
         <AddressContainer
           address={address}
           Input={StyleguideInput}


### PR DESCRIPTION
#### What did you change? \*

It explicitly sets the new `useGeolocation` flag to `true` when using geolocation rules.

Continuation of https://github.com/vtex/address-form/pull/218

#### Why? \*

We were having issues with address forms using geolocation when addresses didn't have a number.

#### How to test it? \*

1) https://kiwi--recorrenciaqa.myvtex.com/account#/addresses
2) New address
3) Type av, select an address without a number
4) Type the number on the specified field.
5) Submit

#### Related to / Depends on?

https://app.clubhouse.io/vtex/story/26043/my-account-address-campo-de-n%C3%BAmero-exibindo-referencia-do-object-para-lojas-do-uruguay

#### Types of changes \*

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical improvements
  <!--- * Required -->
