### PR TITLE
 Fix Schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Expose Site Editor schema properly.
+
 ## [1.11.0] - 2019-11-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.11.1] - 2019-11-27
+
 ### Fixed
 
 - Expose Site Editor schema properly.

--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ export default injectIntl(MyAppLink)
 
 After [creating a new page](#adding-a-new-page-to-my-acccount), you can define the default path that will be rendered when the user opens the URL `/account/`.
 
-1. Open the Storefront admin (`/admin/cms/storefront`).
+1. Open the Site Editor admin (`/admin/cms/site-editor`).
 2. Navigate to the My Account page
-3. Click on the "My Account - Home" extension point on the Storefront's Components menu
+3. Click on the "My Account - Home" extension point on the Site Editor's menu
 4. Fill the field "My Account's default path" to the new path
 
 Following the previous examples, we could fill it with "/points", to open the UserPoints page.

--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,12 @@
 {
   "name": "my-account",
   "vendor": "vtex",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "title": "My Account",
   "description": "User's my account page.",
-  "registries": ["smartcheckout"],
+  "registries": [
+    "smartcheckout"
+  ],
   "dependencies": {
     "vtex.my-cards": "1.x",
     "vtex.my-orders-app": "3.x",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.11.0",
+  "version": "1.11.1",
   "devDependencies": {
     "@vtex/intl-equalizer": "^2.3.0",
     "husky": "^2.4.1"

--- a/react/DefaultPage.tsx
+++ b/react/DefaultPage.tsx
@@ -5,7 +5,7 @@ class DefaultPage extends Component<Props> {
     this.props.onSetDefaultPath(this.props.defaultRoute || '/profile')
   }
 
-  public getSchema() {
+  public static getSchema() {
     return {
       title: 'editor.defaultRoute.name',
       description: 'editor.defaultRoute.description',

--- a/react/DefaultRoute.tsx
+++ b/react/DefaultRoute.tsx
@@ -5,7 +5,7 @@ class DefaultRoute extends Component<Props> {
     this.props.onSetDefaultPath(this.props.defaultRoute || '/profile')
   }
 
-  public getSchema = () => {
+  public static getSchema = () => {
     return {
       title: 'editor.defaultRoute.name',
       description: 'editor.defaultRoute.description',

--- a/react/Menu.tsx
+++ b/react/Menu.tsx
@@ -12,7 +12,7 @@ class Menu extends Component<Props> {
     }
   }
 
-  public getSchema() {
+  public static getSchema() {
     return {
       title: 'editor.menu.name',
       description: 'editor.menu.description',


### PR DESCRIPTION
#### What did you change? \*

In TypeScript to expose a property as `static` you should type them as `static`, not just with `public`. 

With this fix, it's now possible to edit the config of the my account [as is described in the README](https://github.com/vtex-apps/my-account/tree/1.x#defining-the-default-home-page-of-my-account):
![image](https://user-images.githubusercontent.com/284515/69753286-fd5cab80-1131-11ea-9d24-fc494118e238.png)

#### How to test it? \*

https://breno--storecomponents.myvtex.com/admin/app/cms/site-editor/account

#### Related to / Depends on?

Fix https://github.com/vtex-apps/my-account/issues/136

#### Types of changes \*

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical improvements
  <!--- * Required -->
