### PR TITLE
Fix message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Address edit message.
+
 ## [1.13.1] - 2020-04-02
 
 ### Fixed

--- a/react/components/Addresses/AddressForm.tsx
+++ b/react/components/Addresses/AddressForm.tsx
@@ -185,7 +185,7 @@ class AddressForm extends Component<InnerProps & OuterProps, State> {
                   <div className="mb7">
                     <AutoCompletedFields>
                       <span className="c-link pointer">
-                        <FormattedMessage id="address-form.edit" />
+                        <FormattedMessage id="vtex.address-form@4.x::address-form.edit" />
                       </span>
                     </AutoCompletedFields>
                   </div>


### PR DESCRIPTION
#### What did you change? \*
Fixed the message id.

#### Why? \*
It wasn't showing.
Before:
<img width="522" alt="Screen Shot 2020-04-08 at 1 40 25 PM" src="https://user-images.githubusercontent.com/27328184/78811046-a5676880-799f-11ea-9746-c39e2f5a566a.png">

After:
<img width="522" alt="Screen Shot 2020-04-08 at 1 46 22 PM" src="https://user-images.githubusercontent.com/27328184/78811055-a8faef80-799f-11ea-91b4-66a2d7b2c844.png">

#### How to test it? \*
https://edit--boticario.myvtex.com/account#/addresses/new

#### Types of changes \*

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical improvements
  <!--- * Required -->
