### PR TITLE
Fix password message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Password error message.
+
 ## [1.13.3] - 2020-04-14
 
 ### Fixed

--- a/react/components/Profile/PasswordFormBox.tsx
+++ b/react/components/Profile/PasswordFormBox.tsx
@@ -17,7 +17,7 @@ import RedefinePasswordForm from './RedefinePassword'
 import SendAccCodeButton from './SendAccCodeButton'
 import PasswordValidator from './PasswordValidator'
 
-const WRONG_CREDENTIALS = 'Wrong credentials'
+const WRONG_CREDENTIALS = 'WrongCredentials'
 const BLOCKED_USER = 'Blocked'
 const messages = defineMessages({
   code: {
@@ -71,8 +71,8 @@ class PasswordFormBox extends Component<Props, State> {
   }
 
   private handleSetPasswordError = (error: any) => {
-    const wrongPassword = error.toString().indexOf(WRONG_CREDENTIALS) > -1
-    const blockedUser = error.toString().indexOf(BLOCKED_USER) > -1
+    const wrongPassword = error.code.toString().indexOf(WRONG_CREDENTIALS) > -1
+    const blockedUser = error.code.toString().indexOf(BLOCKED_USER) > -1
     this.setState((prevState: any) => ({
       isLoading: false,
       error:


### PR DESCRIPTION
#### What did you change? \*
Changed the error to switch by code instead of message.

#### Why? \*
It was breaking.
before:
![image](https://user-images.githubusercontent.com/27328184/79474213-82ab0480-7fdc-11ea-8ab1-a0f029f45b0f.png)

#### How to test it? \*
https://password--storecomponents.myvtex.com/account#/profile
Try to change your password at my account but misspell your current password, It should show the right message.

#### Types of changes \*

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical improvements
  <!--- * Required -->
