### PR TITLE
Add to lowercase for string comparing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- String comparing at password error message.
+
 ## [1.13.4] - 2020-04-16
 
 ### Fixed

--- a/react/components/Profile/PasswordFormBox.tsx
+++ b/react/components/Profile/PasswordFormBox.tsx
@@ -17,8 +17,8 @@ import RedefinePasswordForm from './RedefinePassword'
 import SendAccCodeButton from './SendAccCodeButton'
 import PasswordValidator from './PasswordValidator'
 
-const WRONG_CREDENTIALS = 'WrongCredentials'
-const BLOCKED_USER = 'Blocked'
+const WRONG_CREDENTIALS = 'wrongcredentials'
+const BLOCKED_USER = 'blocked'
 const messages = defineMessages({
   code: {
     id: 'vtex.store-messages@0.x::personalData.code',
@@ -71,8 +71,9 @@ class PasswordFormBox extends Component<Props, State> {
   }
 
   private handleSetPasswordError = (error: any) => {
-    const wrongPassword = error.code.toString().indexOf(WRONG_CREDENTIALS) > -1
-    const blockedUser = error.code.toString().indexOf(BLOCKED_USER) > -1
+    const wrongPassword =
+      error.code.toLowerCase().indexOf(WRONG_CREDENTIALS) > -1
+    const blockedUser = error.code.toLowerCase().indexOf(BLOCKED_USER) > -1
     this.setState((prevState: any) => ({
       isLoading: false,
       error:


### PR DESCRIPTION
#### What did you change? \*
Added `toLowerCase` for string comparing on password error.

#### Why? \*
Its safer.

#### How to test it? \*
https://password--storecomponents.myvtex.com/
Try to change your password at my account but misspell your current password, It should show the right message.

#### Types of changes \*

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical improvements
  <!--- * Required -->
