### PR TITLE
Fix addresse's cache listing and edition on 0.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Address Edition.
+- Address listing cache.
+
 ## [0.32.0] - 2020-05-12
 
 ### Changed

--- a/react/components/Addresses/AddressForm.tsx
+++ b/react/components/Addresses/AddressForm.tsx
@@ -57,7 +57,7 @@ class AddressForm extends Component<InnerProps & OuterProps, State> {
     // if editing an existing address (address id exists), all fields start as valid
     if (addressValues.addressId) {
       AUTO_COMPLETABLE_FIELDS.forEach(field => {
-        if (address[field].value === null) return
+        if (addressWithValidation[field].value === null) return
 
         addressWithValidation[field].geolocationAutoCompleted = true
         addressWithValidation[field].postalCodeAutoCompleted = true

--- a/react/components/pages/Addresses.tsx
+++ b/react/components/pages/Addresses.tsx
@@ -80,7 +80,7 @@ interface Props {
 }
 
 const enhance = compose<Props, void>(
-  graphql(GET_ADRESSES),
+  graphql(GET_ADRESSES, { options: { fetchPolicy: 'network-only' } }),
   branch(
     ({ data }: { data: Data }) => data.loading,
     renderComponent(AddressesLoading)


### PR DESCRIPTION
#### What did you change? \*

- ditto.
- same as: https://github.com/vtex-apps/my-account/pull/165

#### Why? \*

![image](https://user-images.githubusercontent.com/3926634/82379136-c8545600-99fc-11ea-9871-46950723fd9d.png)

#### How to test it? \*

- login on: http://storev1--recorrenciaqa.myvtex.com/
- with assinaturasqa@mailinator.com
- try to edit an address. 

#### Related to / Depends on?

<!--- Link to an issue or clubhouse task that did motivate this PR or even others PRs that this one depends. -->

#### Types of changes \*

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical improvements
  <!--- * Required -->