### PR TITLE
css handle for content box

### DIFF
--- a/react/components/shared/ContentBox.tsx
+++ b/react/components/shared/ContentBox.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent, ReactElement } from 'react'
 import { Button } from 'vtex.styleguide'
+import classNames from './styles.css'
 
 const ContentBox: FunctionComponent<Props> = ({
   children,
@@ -11,7 +12,7 @@ const ContentBox: FunctionComponent<Props> = ({
   const widthClass = maxWidthStep ? `mw${maxWidthStep}-ns` : ''
   const flexClass = shouldAllowGrowing ? 'flex-auto' : 'flex-none'
   return (
-    <div className={`pb5 pr5-ns ${flexClass} ${widthClass}`}>
+    <div className={`pb5 pr5-ns ${flexClass} ${widthClass} ${classNames.profileMainContainer}`}>
       <article className="ba bw1 b--muted-4 br2 flex flex-column justify-between">
         <main className="ph7 pv6">{children}</main>
         {lowerButton && (

--- a/react/components/shared/styles.css
+++ b/react/components/shared/styles.css
@@ -1,0 +1,3 @@
+.profileMainContainer {
+
+}


### PR DESCRIPTION
#### What did you change? \*

Added a css handle for the content box inside my account profile page

#### Why? \*

This css handle is necessary for removing the default border which is not included in the design of the client

#### How to test it? \*

<!--- Link to a running workspace with some steps to reproduce it or even a screenshot of before/after -->

#### Related to / Depends on?

My account page customisation 

#### Types of changes \*

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ x] Technical improvements
  <!--- * Required -->
