### PR TITLE
Hide back button @1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Hide back button on profile.
+
 ## [1.14.1] - 2020-05-20
 
 ### Fixed

--- a/react/components/pages/Profile.tsx
+++ b/react/components/pages/Profile.tsx
@@ -17,6 +17,7 @@ import NewsletterBox from '../Profile/NewsletterBox'
 export const headerConfig = {
   namespace: `${styles.profile}`,
   titleId: 'vtex.store-messages@0.x::pages.profile',
+  hideBackButton: true,
 }
 
 class ProfileContainer extends Component<Props> {


### PR DESCRIPTION
Same as #172 but at 1.x

> #### What did you change? \*
> I hid the back button from the profile page.
> 
> #### Why? \*
> It was not going anywhere, therefore it isn't needed.

#### How to test it? \*
https://profile--storecomponents.myvtex.com/account#/profile

#### Related to / Depends on?
https://github.com/vtex-apps/my-account-commons/pull/28

#### Types of changes \*

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical improvements
  <!--- * Required -->
