### PR TITLE
Added prop blockDocument to block field in user profile page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Prop `blockDocument` to Enables or disables editing the document field in MyAccount
+- Prop `blockDocument` to Enables or disables editing the document field in My account
 
 ## [1.17.1] - 2020-10-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Added 
-- Added prop `blockDocument` to Enables or disables editing the document field in my account
+### Added
+
+- Prop `blockDocument` to Enables or disables editing the document field in MyAccount
 
 ## [1.17.1] - 2020-10-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added 
+- Added prop `blockDocument` to Enables or disables editing the document field in my account
+
 ## [1.17.1] - 2020-10-06
 
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,7 @@ Now, create the file `store/interfaces.json` and define some interfaces:
 ```
 
 If you want to block the editing of the document in the my account form, use the props `blockDocument`
+
 ```json
 "my-account": {
     "props": { "blockDocument": true },
@@ -47,28 +48,30 @@ If you want to block the editing of the document in the my account form, use the
     ]
   }
 ```
-| Prop name              | Type             | Description                                                                                                                                                                                           | Default value     |
-| ---------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
-| `blockDocument` | `boolean` | Enables or disables editing the document field in my account  | `underfid` |
+
+| Prop name       | Type      | Description                                                 | Default value |
+| --------------- | --------- | ----------------------------------------------------------- | ------------- |
+| `blockDocument` | `boolean` | Enables or disables editing the document field in MyAccount | `undefined`   |
 
 ---
+
 **Usage:** To block the document field, follow these steps:
 
 1. In the index.tsx in /react file, the `blockDocument` property is received from the main store. Pass this property on to AppRouter
 
 ```js
-   <Wrapper>
-        <div className="vtex-account helvetica flex justify-around">
-          <AppRouter blockDocument={this.props.blockDocument} />
-        </div>
-  </Wrapper>
+<Wrapper>
+  <div className="vtex-account helvetica flex justify-around">
+    <AppRouter blockDocument={this.props.blockDocument} />
+  </div>
+</Wrapper>
 ```
 
 2. Pass the property to the `ProfileEdit` component
 
 ```js
    component: ComponentClass<void, unknown> | FC
-    
+
   }) => {
     return <Route exact key={path} path={path} component={component}/>
   }
@@ -81,7 +84,9 @@ If you want to block the editing of the document in the my account form, use the
       { path: '/profile/edit', component: ()=><ProfileEdit blockDocument={this.props.blockDocument}/> },
     ]
 ```
-3. In the `ProfileEdit` component, pass the property to the` ProfileFormBox` component
+
+3. In the `ProfileEdit` component, pass the property to the`ProfileFormBox` component
+
 ```js
   const { profile, handleError, blockDocument } = this.props
     return (
@@ -94,8 +99,9 @@ If you want to block the editing of the document in the my account form, use the
     )
   }
 ```
-4. In the `ProfileFormBox` component, pass the property to the` ProfileContainer` component.
-Just remembering that this component is imported from the **vtex.profile-form** app
+
+4. In the `ProfileFormBox` component, pass the property to the`ProfileContainer` component.
+   Just remembering that this component is imported from the **vtex.profile-form** app
 
 ```js
     <ProfileContainer
@@ -105,6 +111,7 @@ Just remembering that this component is imported from the **vtex.profile-form** 
       blockDocument={blockDocument}
     >
 ```
+
 5. Follow the steps below in the app ** vtex.profile-form **
 
 The names `my-app-link`, `my-app-page`, `MyAppLink` and `MyAppPage` may be whatever it makes more sense for you app.

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,74 @@ Now, create the file `store/interfaces.json` and define some interfaces:
 }
 ```
 
+If you want to block the editing of the document in the my account form, use the props `blockDocument`
+```json
+"my-account": {
+    "props": { "blockDocument": true },
+    "blocks": [
+    ]
+  }
+```
+| Prop name              | Type             | Description                                                                                                                                                                                           | Default value     |
+| ---------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| `blockDocument` | `boolean` | Enables or disables editing the document field in my account  | `underfid` |
+
+---
+**Usage:** To block the document field, follow these steps:
+
+1. In the index.tsx in /react file, the `blockDocument` property is received from the main store. Pass this property on to AppRouter
+
+```js
+   <Wrapper>
+        <div className="vtex-account helvetica flex justify-around">
+          <AppRouter blockDocument={this.props.blockDocument} />
+        </div>
+  </Wrapper>
+```
+
+2. Pass the property to the `ProfileEdit` component
+
+```js
+   component: ComponentClass<void, unknown> | FC
+    
+  }) => {
+    return <Route exact key={path} path={path} component={component}/>
+  }
+  public render() {
+    const routes = [
+      { path: '/addresses', component: Addresses },
+      { path: '/addresses/new', component: AddressCreate },
+      { path: '/addresses/edit/:id', component: AddressEdit },
+      { path: '/profile', component: Profile },
+      { path: '/profile/edit', component: ()=><ProfileEdit blockDocument={this.props.blockDocument}/> },
+    ]
+```
+3. In the `ProfileEdit` component, pass the property to the` ProfileFormBox` component
+```js
+  const { profile, handleError, blockDocument } = this.props
+    return (
+      <ProfileFormBox
+        profile={profile}
+        onDataSave={this.handleGoBack}
+        onError={handleError}
+        blockDocument={blockDocument}
+      />
+    )
+  }
+```
+4. In the `ProfileFormBox` component, pass the property to the` ProfileContainer` component.
+Just remembering that this component is imported from the **vtex.profile-form** app
+
+```js
+    <ProfileContainer
+      defaultProfile={profile}
+      onSubmit={this.handleSubmit}
+      shouldShowExtendedGenders={showGenders}
+      blockDocument={blockDocument}
+    >
+```
+5. Follow the steps below in the app ** vtex.profile-form **
+
 The names `my-app-link`, `my-app-page`, `MyAppLink` and `MyAppPage` may be whatever it makes more sense for you app.
 
 Lastly, create a `store/plugins.json` file like so:

--- a/react/components/AppRouter.tsx
+++ b/react/components/AppRouter.tsx
@@ -1,4 +1,4 @@
-import React, { Component, Fragment, ComponentClass } from 'react'
+import React, { Component, Fragment, FC, ComponentClass } from 'react'
 import Media from 'react-media'
 import {
   Route,
@@ -15,7 +15,15 @@ import AddressCreate from './pages/AddressCreate'
 import AddressEdit from './pages/AddressEdit'
 import Menu from './Menu'
 
-class AppRouter extends Component {
+interface AppRouterProps {
+  blockDocument?: boolean
+}
+
+class AppRouter extends Component<AppRouterProps> {
+  constructor(props: AppRouterProps) {
+    super(props)
+  }
+
   public state = { defaultPath: '' }
 
   private handleDefaultPath = (defaultPath: string) => {
@@ -42,8 +50,10 @@ class AppRouter extends Component {
     component,
   }: {
     path: string
-    component: ComponentClass<void, unknown>
-  }) => <Route exact key={path} path={path} component={component} />
+   component: ComponentClass<void, unknown> | FC
+
+  }) => <Route exact key={path} path={path} component={component}/>
+
 
   public render() {
     const routes = [
@@ -51,7 +61,7 @@ class AppRouter extends Component {
       { path: '/addresses/new', component: AddressCreate },
       { path: '/addresses/edit/:id', component: AddressEdit },
       { path: '/profile', component: Profile },
-      { path: '/profile/edit', component: ProfileEdit },
+      { path: '/profile/edit', component: ()=><ProfileEdit blockDocument={this.props.blockDocument}/> },
     ]
 
     return (

--- a/react/components/AppRouter.tsx
+++ b/react/components/AppRouter.tsx
@@ -15,15 +15,11 @@ import AddressCreate from './pages/AddressCreate'
 import AddressEdit from './pages/AddressEdit'
 import Menu from './Menu'
 
-interface AppRouterProps {
+interface Props {
   blockDocument?: boolean
 }
 
-class AppRouter extends Component<AppRouterProps> {
-  constructor(props: AppRouterProps) {
-    super(props)
-  }
-
+class AppRouter extends Component<Props> {
   public state = { defaultPath: '' }
 
   private handleDefaultPath = (defaultPath: string) => {
@@ -50,10 +46,8 @@ class AppRouter extends Component<AppRouterProps> {
     component,
   }: {
     path: string
-   component: ComponentClass<void, unknown> | FC
-
-  }) => <Route exact key={path} path={path} component={component}/>
-
+    component: ComponentClass<void, unknown> | FC
+  }) => <Route exact key={path} path={path} component={component} />
 
   public render() {
     const routes = [
@@ -61,7 +55,12 @@ class AppRouter extends Component<AppRouterProps> {
       { path: '/addresses/new', component: AddressCreate },
       { path: '/addresses/edit/:id', component: AddressEdit },
       { path: '/profile', component: Profile },
-      { path: '/profile/edit', component: ()=><ProfileEdit blockDocument={this.props.blockDocument}/> },
+      {
+        path: '/profile/edit',
+        component: () => (
+          <ProfileEdit blockDocument={this.props.blockDocument} />
+        ),
+      },
     ]
 
     return (

--- a/react/components/Profile/ProfileFormBox.tsx
+++ b/react/components/Profile/ProfileFormBox.tsx
@@ -84,7 +84,7 @@ class ProfileFormBox extends Component<InnerProps & OutterProps, State> {
   }
 
   public render() {
-    const { profile, settings, runtime, cssHandles } = this.props
+    const { profile, settings, runtime, cssHandles, blockDocument } = this.props
     const { isLoading } = this.state
     const showGenders = settings?.showGenders
 
@@ -98,6 +98,7 @@ class ProfileFormBox extends Component<InnerProps & OutterProps, State> {
               defaultProfile={profile}
               onSubmit={this.handleSubmit}
               shouldShowExtendedGenders={showGenders}
+              blockDocument={blockDocument}
               SubmitButton={
                 <Button type="submit" block size="small" isLoading={isLoading}>
                   <FormattedMessage id="vtex.profile-form@3.x::profile-form.save-changes" />
@@ -131,7 +132,8 @@ interface InnerProps {
 interface OutterProps {
   onDataSave: () => void
   onError: (error: any) => void
-  profile: Profile
+  profile: Profile,
+  blockDocument?: boolean
 }
 
 const enhance = compose<InnerProps & OutterProps, OutterProps>(

--- a/react/components/Profile/ProfileFormBox.tsx
+++ b/react/components/Profile/ProfileFormBox.tsx
@@ -132,7 +132,7 @@ interface InnerProps {
 interface OutterProps {
   onDataSave: () => void
   onError: (error: any) => void
-  profile: Profile,
+  profile: Profile
   blockDocument?: boolean
 }
 

--- a/react/components/pages/ProfileEdit.tsx
+++ b/react/components/pages/ProfileEdit.tsx
@@ -22,13 +22,14 @@ class ProfileEdit extends Component<Props> {
   }
 
   public render() {
-    const { profile, handleError } = this.props
+    const { profile, handleError, blockDocument } = this.props
 
     return (
       <ProfileFormBox
         profile={profile}
         onDataSave={this.handleGoBack}
         onError={handleError}
+        blockDocument={blockDocument}
       />
     )
   }
@@ -38,15 +39,18 @@ interface Props extends InjectedContentWrapperProps {
   data: { profile: Profile }
   profile: Profile
   history: any
+  blockDocument?: boolean
 }
 
-const enhance = compose<Props, void>(
+const enhance = compose<Props, { blockDocument?: boolean}>(
   graphql(GET_PROFILE),
   branch<Props>(
     ({ data }) => data.profile == null,
     renderComponent(ProfileEditLoading)
   ),
-  withProps(({ data }: Props) => ({ profile: data.profile })),
+  withProps(({ data, blockDocument }: Props) => {
+    return { profile: data.profile, blockDocument }
+  }),
   withRouter,
   withContentWrapper({ headerConfig, handle: 'profileEdit' })
 )

--- a/react/components/pages/ProfileEdit.tsx
+++ b/react/components/pages/ProfileEdit.tsx
@@ -42,14 +42,14 @@ interface Props extends InjectedContentWrapperProps {
   blockDocument?: boolean
 }
 
-const enhance = compose<Props, { blockDocument?: boolean}>(
+const enhance = compose<Props, { blockDocument?: boolean }>(
   graphql(GET_PROFILE),
   branch<Props>(
     ({ data }) => data.profile == null,
     renderComponent(ProfileEditLoading)
   ),
-  withProps(({ data, blockDocument }: Props) => {
-    return { profile: data.profile, blockDocument }
+  withProps(({ data }: Props) => {
+    return { profile: data.profile }
   }),
   withRouter,
   withContentWrapper({ headerConfig, handle: 'profileEdit' })

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -5,7 +5,14 @@ import AppRouter from './components/AppRouter'
 import Wrapper from './components/MyAccountWrapper'
 import { logGeneralErrors } from './utils/splunk'
 
-class MyAccount extends Component {
+interface MyAccountProps {
+  blockDocument?: boolean
+}
+
+class MyAccount extends Component<MyAccountProps> {
+  constructor(props: MyAccountProps) {
+    super(props)
+  }
   public componentDidCatch(error: unknown, info: unknown) {
     if (window.__RUNTIME__.workspace === 'master') {
       logGeneralErrors(error, info)
@@ -16,7 +23,7 @@ class MyAccount extends Component {
     return (
       <Wrapper>
         <div className="vtex-account helvetica flex justify-around">
-          <AppRouter />
+          <AppRouter blockDocument={this.props.blockDocument} />
         </div>
       </Wrapper>
     )

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -5,14 +5,11 @@ import AppRouter from './components/AppRouter'
 import Wrapper from './components/MyAccountWrapper'
 import { logGeneralErrors } from './utils/splunk'
 
-interface MyAccountProps {
+interface Props {
   blockDocument?: boolean
 }
 
-class MyAccount extends Component<MyAccountProps> {
-  constructor(props: MyAccountProps) {
-    super(props)
-  }
+class MyAccount extends Component<Props> {
   public componentDidCatch(error: unknown, info: unknown) {
     if (window.__RUNTIME__.workspace === 'master') {
       logGeneralErrors(error, info)


### PR DESCRIPTION
#### What did you change? \*

A property has been added to the module called blockDocument

#### Why? \*
The customer needed to block the document field (cpf). Once added, the user should no longer edit. The customer wanted unique accounts per user.

#### How to test it? \*

1. Pass the blockDocument property in the declaration of the my-account app in the store

2. Link the vtex.profile-forme app on the tksio-549 branch in the my-account module. It is a dependency.

3. Link the three store / my-account / profile-form repositories and change the property value in the store. By default the speaker is underfid.
If you do not pass the property or pass the false value, the field allows changes.
If it is set to true and the field still has no saved value, the field will also allow editing, if the field is already saved, the field is blocked.

https://profileform--tokstokio.myvtex.com/account/#/profile/edit

#### prop
![image](https://user-images.githubusercontent.com/78736383/107518517-dbf8ab80-6b8d-11eb-932e-cce56e472d34.png)

#### Before
![bofore](https://user-images.githubusercontent.com/78736383/107516673-83c0aa00-6b8b-11eb-9746-b56e0bcebc44.PNG)

#### After
![affter](https://user-images.githubusercontent.com/78736383/107516749-9aff9780-6b8b-11eb-9596-ab27c35b70d6.PNG)

#### Related to / Depends on?

https://listastokstok.atlassian.net/browse/TKSIO-549

#### Types of changes \*

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical improvements

