### PR TITLE
Feature/idcs 599/hide my authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+
+- **authentication.showMyAuthentication** app setting.
+
+### Added
+
+- **authentication.hideMyAuthentication** app setting (hidden from UI).
+
 ## [0.36.0] - 2021-08-26
 
 ### Added

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -7,5 +7,5 @@ type AppSettings {
   useMap: Boolean
   showGenders: Boolean
   showMyCards: Boolean
-  showMyAuthentication: Boolean
+  hideMyAuthentication: Boolean
 }

--- a/manifest.json
+++ b/manifest.json
@@ -54,17 +54,6 @@
             "default": true
           }
         }
-      },
-      "authentication": {
-        "type": "object",
-        "title": "Authentication",
-        "properties": {
-          "showMyAuthentication": {
-            "type": "boolean",
-            "title": "Visible",
-            "default": false
-          }
-        }
       }
     }
   },

--- a/node/resolvers/settings.ts
+++ b/node/resolvers/settings.ts
@@ -15,7 +15,7 @@ async function settings(_: unknown, __: unknown, ctx: ServiceContext) {
     useMap: result.addresses && result.addresses.useMap,
     showGenders: result.profile && result.profile.showGenders,
     showMyCards: result.cards && result.cards.showMyCards,
-    showMyAuthentication: (result.authentication && result.authentication.showMyAuthentication) || false,
+    hideMyAuthentication: (result.authentication && result.authentication.hideMyAuthentication) || false,
   }
 }
 
@@ -23,7 +23,7 @@ interface Settings {
   addresses?: { useMap: boolean }
   profile?: { showGenders: boolean }
   cards?: { showMyCards: boolean }
-  authentication?: { showMyAuthentication: boolean }
+  authentication?: { hideMyAuthentication: boolean }
 }
 
 export default settings

--- a/react/components/Menu/MenuLinksList.tsx
+++ b/react/components/Menu/MenuLinksList.tsx
@@ -25,15 +25,15 @@ const messages = defineMessages({
 
 interface RenderLinksOptions {
   showMyCards: boolean | null
-  showMyAuthentication: boolean | null
+  hideMyAuthentication: boolean | null
 }
 
-function renderLinks(links: Link[], { showMyCards, showMyAuthentication }: RenderLinksOptions) {
+function renderLinks(links: Link[], { showMyCards, hideMyAuthentication }: RenderLinksOptions) {
   const linksToDisplay = links.filter(link => {
     if (showMyCards === false && link.path === '/cards') {
       return false
     }
-    if (showMyAuthentication === false && link.path === '/authentication') {
+    if (hideMyAuthentication === true && link.path === '/authentication') {
       return false
     }
     return true
@@ -57,7 +57,7 @@ class MenuLinksList extends Component<Props> {
     const { intl, settings } = this.props
     const {
       showMyCards = false,
-      showMyAuthentication = false,
+      hideMyAuthentication = false,
     } = settings || {}
 
     const defaultLinks = [
@@ -76,14 +76,14 @@ class MenuLinksList extends Component<Props> {
         <ExtensionPoint
           id="menu-links-before"
           render={(links: Link[]) =>
-            renderLinks(links, { showMyCards, showMyAuthentication })
+            renderLinks(links, { showMyCards, hideMyAuthentication })
           }
         />
-        {renderLinks(defaultLinks, { showMyCards, showMyAuthentication })}
+        {renderLinks(defaultLinks, { showMyCards, hideMyAuthentication })}
         <ExtensionPoint
           id="menu-links-after"
           render={(links: Link[]) =>
-            renderLinks(links, { showMyCards, showMyAuthentication })
+            renderLinks(links, { showMyCards, hideMyAuthentication })
           }
         />
         <AuthService.RedirectLogout returnUrl="/">

--- a/react/components/shared/withSettings.tsx
+++ b/react/components/shared/withSettings.tsx
@@ -22,6 +22,6 @@ export function withSettings(
 export interface Settings {
   showGenders: boolean
   showMyCards: boolean | null
-  showMyAuthentication: boolean | null
+  hideMyAuthentication: boolean | null
   useMap: boolean
 }

--- a/react/graphql/settings.gql
+++ b/react/graphql/settings.gql
@@ -3,7 +3,7 @@ query MyAccountSettings {
     cacheId
     showGenders
     showMyCards
-    showMyAuthentication
+    hideMyAuthentication
     useMap
   }
 }


### PR DESCRIPTION
#### What did you change? \*

Removed `showMyAuthentication` checkbox from [app settings](https://rafaprtest--recorrenciaqa.myvtex.com/admin/apps/vtex.my-account@0.36.0/setup/).

Before

![image](https://user-images.githubusercontent.com/22064061/112517053-a4794380-8d76-11eb-9b05-8270d96a408f.png)

After

![image](https://user-images.githubusercontent.com/22064061/134265078-9a5d4d93-786e-492a-a78f-877ecf274fff.png)

Also, added `hideMyAuthentication` setting to the app. This setting is hidden from the [app settings](https://rafaprtest--recorrenciaqa.myvtex.com/admin/apps/vtex.my-account@0.36.0/setup/) UI, but may be set directly through the API.

#### Why? \*

27/09/2021 will be the end date of the [My Authentication Breaking Change](https://help.vtex.com/pt/announcements/aba-my-authentication-do-my-account--5OETzDR8d5qt13atEBxsB9?utm_source=admin-top-nav). At this date, this should be deployed to force the `my-authentication` UI to appear at every VTEX store.

![image](https://user-images.githubusercontent.com/22064061/134263566-17b45bd9-4f89-44f1-bdf5-e4e82692e98b.png)

In case any Store wasn't prepared for the Breaking Change deadline, we will be able to use the new `hideMyAuthentication` setting to temporarily revert this change.

#### How to test it? \*

You can check the MyAccount 0.x Settings UI [here](https://rafaprtest--recorrenciaqa.myvtex.com/admin/apps/vtex.my-account@0.36.0/setup/). You can see the MyAuthentication tab is now visible by default [here](https://recorrenciaqa.vtexcommercestable.com.br/_secure/Account/?workspace=rafaprtest#/authentication).

You can see that the `showMyAuthentication` setting is now ignored:

![image](https://user-images.githubusercontent.com/22064061/134263545-3b9ba17e-2ab2-44c6-9a8e-2ea4afebd80b.png)

![image](https://user-images.githubusercontent.com/22064061/134263566-17b45bd9-4f89-44f1-bdf5-e4e82692e98b.png)

You can see that the `hideMyAuthentication` setting (set manually) works:

![image](https://user-images.githubusercontent.com/22064061/134264991-b6f4d32e-fc4b-446c-9d1b-204bee7e32b7.png)

![image](https://user-images.githubusercontent.com/22064061/134265010-072a5ae1-4159-4c49-a2a4-ce2a02915ad5.png)

#### Related to / Depends on?

Related to https://github.com/vtex-apps/my-account/pull/207

#### Types of changes \*

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical improvements
  <!--- * Required -->
