### PR TITLE
Feature/idcs 600/hide my authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+
+- **authentication.showMyAuthentication** app setting.
+
+### Added
+
+- **authentication.hideMyAuthentication** app setting (hidden from UI).
+
 ## [1.21.0] - 2021-09-16
 
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -7,5 +7,5 @@ type AppSettings {
   useMap: Boolean
   showGenders: Boolean
   showMyCards: Boolean
-  showMyAuthentication: Boolean
+  hideMyAuthentication: Boolean
 }

--- a/manifest.json
+++ b/manifest.json
@@ -57,17 +57,6 @@
             "default": true
           }
         }
-      },
-      "authentication": {
-        "type": "object",
-        "title": "Authentication",
-        "properties": {
-          "showMyAuthentication": {
-            "type": "boolean",
-            "title": "Visible",
-            "default": false
-          }
-        }
       }
     }
   },

--- a/node/resolvers/settings.ts
+++ b/node/resolvers/settings.ts
@@ -15,7 +15,7 @@ async function settings(_: unknown, __: unknown, ctx: ServiceContext) {
     useMap: result.addresses && result.addresses.useMap,
     showGenders: result.profile && result.profile.showGenders,
     showMyCards: result.cards && result.cards.showMyCards,
-    showMyAuthentication: (result.authentication && result.authentication.showMyAuthentication) || false,
+    hideMyAuthentication: (result.authentication && result.authentication.hideMyAuthentication) || false,
   }
 }
 
@@ -23,7 +23,7 @@ interface Settings {
   addresses?: { useMap: boolean }
   profile?: { showGenders: boolean }
   cards?: { showMyCards: boolean }
-  authentication?: { showMyAuthentication: boolean }
+  authentication?: { hideMyAuthentication: boolean }
 }
 
 export default settings

--- a/react/components/Menu/index.tsx
+++ b/react/components/Menu/index.tsx
@@ -18,19 +18,19 @@ const CSS_HANDLES = ['css', 'menu', 'menuLinks', 'menuLink'] as const
 
 interface RenderLinksOptions {
   showMyCards: boolean | null
-  showMyAuthentication?: boolean | null
+  hideMyAuthentication?: boolean | null
 }
 
 function renderLinks(
   links: Link[],
-  { showMyCards, showMyAuthentication }: RenderLinksOptions
+  { showMyCards, hideMyAuthentication }: RenderLinksOptions
 ) {
   const linksToDisplay = links.filter(link => {
     if (showMyCards === false && link.path === '/cards') {
       return false
     }
 
-    if (showMyAuthentication === false && link.path === '/authentication') {
+    if (hideMyAuthentication === true && link.path === '/authentication') {
       return false
     }
 
@@ -51,7 +51,7 @@ class Menu extends Component<Props, { isModalOpen: boolean }> {
 
   public render() {
     const { cssHandles, intl, settings } = this.props
-    const { showMyCards = false, showMyAuthentication = false } = settings || {}
+    const { showMyCards = false, hideMyAuthentication = false } = settings || {}
 
     return (
       <aside
@@ -62,7 +62,7 @@ class Menu extends Component<Props, { isModalOpen: boolean }> {
           <ExtensionPoint
             id="my-account-menu"
             render={(links: Link[]) =>
-              renderLinks(links, { showMyCards, showMyAuthentication })
+              renderLinks(links, { showMyCards, hideMyAuthentication })
             }
           />
           <AuthState skip scope="STORE">

--- a/react/components/shared/withSettings.tsx
+++ b/react/components/shared/withSettings.tsx
@@ -23,6 +23,6 @@ export function withSettings(
 export interface Settings {
   showGenders: boolean
   showMyCards: boolean | null
-  showMyAuthentication: boolean | null
+  hideMyAuthentication: boolean | null
   useMap: boolean
 }

--- a/react/graphql/settings.gql
+++ b/react/graphql/settings.gql
@@ -3,7 +3,7 @@ query MyAccountSettings {
     cacheId
     showGenders
     showMyCards
-    showMyAuthentication
+    hideMyAuthentication
     useMap
   }
 }


### PR DESCRIPTION
#### What did you change? \*

Removed `showMyAuthentication` checkbox from [app settings](https://rafaprtest--storecomponents.myvtex.com/admin/apps/vtex.my-account@1.21.0/setup/).

Before

![image](https://user-images.githubusercontent.com/22064061/134267673-eff5cb51-5527-4662-9f80-0faf02f97ebb.png)

After

![image](https://user-images.githubusercontent.com/22064061/134267622-fb9f2bba-7343-4a6b-9cbe-d2ba6bf94d43.png)

Also, added `hideMyAuthentication` setting to the app. This setting is hidden from the [app settings](https://rafaprtest--storecomponents.myvtex.com/admin/apps/vtex.my-account@1.21.0/setup/) UI, but may be set directly through the API.

#### Why? \*

27/09/2021 will be the end date of the [My Authentication Breaking Change](https://help.vtex.com/pt/announcements/aba-my-authentication-do-my-account--5OETzDR8d5qt13atEBxsB9?utm_source=admin-top-nav). At this date, this should be deployed to force the `my-authentication` UI to appear at every VTEX store.

![image](https://user-images.githubusercontent.com/22064061/134267781-e158db05-2059-424c-b433-dd1f17d0f7eb.png)

In case any Store wasn't prepared for the Breaking Change deadline, we will be able to use the new `hideMyAuthentication` setting to temporarily revert this change.

#### How to test it? \*

You can check the MyAccount 1.x Settings UI [here](https://rafaprtest--storecomponents.myvtex.com/admin/apps/vtex.my-account@1.21.0/setup/). You can see the MyAuthentication tab is now visible by default [here](https://rafaprtest--storecomponents.myvtex.com/account#/authentication).

You can see that the `showMyAuthentication` setting is now ignored:

![image](https://user-images.githubusercontent.com/22064061/134267967-c8e4cd3c-9a03-4527-a41d-09b4d93fe4b6.png)

![image](https://user-images.githubusercontent.com/22064061/134267781-e158db05-2059-424c-b433-dd1f17d0f7eb.png)

You can see that the `hideMyAuthentication` setting (set manually) works:

![image](https://user-images.githubusercontent.com/22064061/134268109-c59ebf74-1544-4e8b-8c80-5d786edec9f8.png)

![image](https://user-images.githubusercontent.com/22064061/134268127-57a7fcf0-b9ab-4951-a3a8-23a9ecd06918.png)

#### Related to / Depends on?

Related to https://github.com/vtex-apps/my-account/pull/206

#### Types of changes \*

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical improvements
  <!--- * Required -->
