### PR TITLE
Add "store" domain to my-account-extension-example messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- "store" domain to my-account-extension-example messages (#258)
+
 ## [1.25.0] - 2022-02-10
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Added
-
-- "store" domain to my-account-extension-example messages (#258)
-
 ## [1.25.0] - 2022-02-10
 
 ### Removed

--- a/my-account-extension-example/manifest.json
+++ b/my-account-extension-example/manifest.json
@@ -1,8 +1,8 @@
 {
-  "name": "my-account-plugin-sample",
+  "name": "my-account-extension-example",
   "vendor": "vtex",
   "version": "0.0.0",
-  "title": "My Account Sample Plugin",
+  "title": "My Account Extension Example",
   "description": "",
   "mustUpdateAt": "2019-07-09",
   "dependencies": {

--- a/my-account-extension-example/messages/context.json
+++ b/my-account-extension-example/messages/context.json
@@ -1,3 +1,3 @@
 {
-  "userSupport.link": "User Support"
+  "store/userSupport.link": "User Support"
 }

--- a/my-account-extension-example/messages/en.json
+++ b/my-account-extension-example/messages/en.json
@@ -1,3 +1,3 @@
 {
-  "userSupport.link": "User Support"
+  "store/userSupport.link": "User Support"
 }

--- a/my-account-extension-example/react/MyAppLink.js
+++ b/my-account-extension-example/react/MyAppLink.js
@@ -4,7 +4,7 @@ import { intlShape, injectIntl } from 'react-intl'
 const MyAppLink = ({ render, intl }) => {
   return render([
     {
-      name: intl.formatMessage({ id: 'userSupport.link' }),
+      name: intl.formatMessage({ id: 'store/userSupport.link' }),
       path: '/support',
     },
   ])


### PR DESCRIPTION
#### What did you change? \*

- Added `store` domain to messages used in `my-account-extension-example`
- Changed small details in `manifest.json` to improve consistency in the boilerplate code

#### Why? \*

I was getting this error from builder hub:

<img width="1327" alt="Screen Shot 2022-04-05 at 14 19 58" src="https://user-images.githubusercontent.com/2094877/161814024-9641d8d0-4abe-45ac-854d-d535a4d59852.png">

#### How to test it? \*

1. Copy the code for the example like this: 
   ``` 
   npx degit 'vtex-apps/my-account/my-account-extension-example#fix/1.x/my-account-extension-example' vtex.my-account-extension-example
   ````
2. Run `vtex link` in a development workspace
3. You should no longer see the builder hub error
#### Related to / Depends on?

I started investigating this because of this VTEX Community question:

https://community.vtex.com/t/criar-uma-nova-aba-custom-em-vtex-my-account/26493/7

#### Types of changes \*

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical improvements
  <!--- * Required -->
