### PR TITLE
add a span on menu username on my account

### DIFF
--- a/react/components/Menu/UserInfo.tsx
+++ b/react/components/Menu/UserInfo.tsx
@@ -37,7 +37,7 @@ const UserInfo: FunctionComponent<Props> = ({ profilePicture, firstName }) => {
             ,
           </div>
           <div className={`${cssHandles.userName} f4 c-on-base fw3 nowrap`}>
-            {firstName}!
+            {firstName}<span>!</span>
           </div>
         </div>
       ) : (


### PR DESCRIPTION
#### What did you change? \*

Added a span tag to be able to handle the exclamation mark after the user name in the menu

#### Why? \*

Because our client needs to hide the exclamation and we have no way to manipulate the exclamation

#### How to test it? \*

Link in this workspace: [workspace to test](https://username--canali.myvtex.com) and go to my account.
With the username registered, in the Menu will appear the userName with the exclamation inside the added span.

#### Related to / Depends on?

<!---  -->

#### Types of changes \*

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical improvements
  <!--- * Required -->
