### PR TITLE
Scroll to top when user edits an address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Scroll to top when user edits an address
+
 ## [1.26.0] - 2022-05-02
 
 ## [1.25.0] - 2022-02-10
@@ -40,7 +44,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **authentication.hideMyAuthentication** app setting (hidden from UI).
 
 ## [1.21.0] - 2021-09-16
-
 
 ### Added
 

--- a/node/package.json
+++ b/node/package.json
@@ -22,7 +22,7 @@
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.138.0/public/@types/vtex.styleguide"
   },
   "dependencies": {
-    "@vtex/api": "6.45.12"
+    "@vtex/api": "6.45.13"
   },
   "version": "1.26.0"
 }

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -210,10 +210,10 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-"@vtex/api@6.45.12":
-  version "6.45.12"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.12.tgz#b13c04398b12f576263ea823369f09c970d57479"
-  integrity sha512-SVLKo+Q/TxQy+1UKzH8GswTI3F2OCRCLfgaNQOrVAVdbM6Ci4wzTeX8j/S4Q1aEEnqBFlH/wVpHf8I6NBa+g9A==
+"@vtex/api@6.45.13":
+  version "6.45.13"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.13.tgz#836c392fa9567009e34559f08698f6efc95e88cc"
+  integrity sha512-P22/ObNdsgLvagetcDrovFfSXHe8Jb4yHud4U0rXHfIYEIMSnEdQ/QHujF3CEa5AiZnvbR/5W5ynGtWHYHOv9A==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"

--- a/react/components/Menu/index.tsx
+++ b/react/components/Menu/index.tsx
@@ -56,7 +56,11 @@ class Menu extends Component<Props, { isModalOpen: boolean }> {
 
   public render() {
     const { cssHandles, intl, settings, runtime } = this.props
-    const { showMyCards = false, showMyOrders = false, showMyAddresses = false } = settings || {}
+    const {
+      showMyCards = false,
+      showMyOrders = false,
+      showMyAddresses = false,
+    } = settings || {}
 
     return (
       <aside

--- a/react/components/pages/Addresses.tsx
+++ b/react/components/pages/Addresses.tsx
@@ -51,6 +51,7 @@ class Addresses extends Component<Props> {
   }
 
   private handleStartEditing = (address: Address) => {
+    window.scroll({ top: 0, left: 0, behavior: 'auto' })
     this.props.history.push(`/addresses/edit/${address.addressId}`)
   }
 


### PR DESCRIPTION
#### What did you change? \*

Added a scroll to top when user clicks on the edit address button.

#### Why? \*

On mobile, if a user had a number of addresses in a vertical list, when clicking to edit an address their browser scroll position would remain at the bottom of the page, wherever they were when they clicked.

This PR adds a simple scroll to top method to ensure that users are sent to the top of the page when they enter the address edit interface.

#### How to test it? \*

New version is linked here: https://myaccountscroll--worldwidegolf.myvtex.com/
Go to My Account / Addresses, add a few addresses if you don't have any already, go into mobile mode, and click on the EDIT button for an address somewhere lower in the page. You should be scrolled to the top so the Edit Address header is on screen after navigation occurs.

#### Types of changes \*

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical improvements
  <!--- * Required -->
