### PR TITLE
enable external links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Support for external link at my account menu
+
 ## [1.27.1] - 2024-02-15
 
 ### Fixed

--- a/react/components/Menu/MenuLink.tsx
+++ b/react/components/Menu/MenuLink.tsx
@@ -4,8 +4,7 @@ import type { RouteComponentProps } from 'vtex.my-account-commons/Router'
 import { Link, withRouter } from 'vtex.my-account-commons/Router'
 
 const MenuLink: FunctionComponent<Props> = ({ path, name, location }) => {
-
-  const isExternal = path.startsWith('http://') || path.startsWith('https://');
+  const isExternal = path.startsWith('http://') || path.startsWith('https://')
 
   return isExternal ? (
     <a
@@ -28,8 +27,8 @@ const MenuLink: FunctionComponent<Props> = ({ path, name, location }) => {
     >
       {name}
     </Link>
-  );
-};
+  )
+}
 
 interface Props extends RouteComponentProps {
   path: string

--- a/react/components/Menu/MenuLink.tsx
+++ b/react/components/Menu/MenuLink.tsx
@@ -4,7 +4,7 @@ import type { RouteComponentProps } from 'vtex.my-account-commons/Router'
 import { Link, withRouter } from 'vtex.my-account-commons/Router'
 
 const MenuLink: FunctionComponent<Props> = ({ path, name, location }) => {
-  console.log("bibi 2", path, location.pathname.indexOf(path))
+
   const isExternal = path.startsWith('http://') || path.startsWith('https://');
 
   return isExternal ? (

--- a/react/components/Menu/MenuLink.tsx
+++ b/react/components/Menu/MenuLink.tsx
@@ -4,7 +4,19 @@ import type { RouteComponentProps } from 'vtex.my-account-commons/Router'
 import { Link, withRouter } from 'vtex.my-account-commons/Router'
 
 const MenuLink: FunctionComponent<Props> = ({ path, name, location }) => {
-  return (
+  console.log("bibi 2", path, location.pathname.indexOf(path))
+  const isExternal = path.startsWith('http://') || path.startsWith('https://');
+
+  return isExternal ? (
+    <a
+      href={path}
+      className="vtex-account_menu-link f6 no-underline db hover-near-black pv5 mv3 pl5 bl bw2 nowrap c-on-base b b--action-primary"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      {name}
+    </a>
+  ) : (
     <Link
       to={path}
       className={`
@@ -16,8 +28,8 @@ const MenuLink: FunctionComponent<Props> = ({ path, name, location }) => {
     >
       {name}
     </Link>
-  )
-}
+  );
+};
 
 interface Props extends RouteComponentProps {
   path: string


### PR DESCRIPTION
#### What did you change? \*

Enable external links for my-account

#### Why? \*

When using external SSOs the client needs to send the client to the external page in order to change the password:
<img width="652" alt="image" src="https://github.com/vtex-apps/my-account/assets/67066494/72e91e8a-344c-4484-beac-02fb6afb673b">


https://github.com/vtex-apps/my-account/assets/67066494/227e5033-8d03-40aa-9425-3695c38e80dc


#### How to test it? \*

Beta version: `vtex.my-account@1.27.2-hkignore`

#### Related to / Depends on?

<!--- Link to an issue or clubhouse task that did motivate this PR or even others PRs that this one depends. -->

#### Types of changes \*

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical improvements
  <!--- * Required -->
