### PR TITLE
Add: filter logic for "pickup" addressType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Filter out "pickup" addresses type temporarily while is still being saved at Profile V2.
+
 ## [1.27.1] - 2024-02-15
 
 ### Fixed

--- a/react/components/pages/Addresses.tsx
+++ b/react/components/pages/Addresses.tsx
@@ -62,13 +62,20 @@ class Addresses extends Component<Props> {
       <div
         className={`${cssHandles.addressBox} flex flex-wrap-ns items-start-ns relative tl`}
       >
-        {this.props.addresses.map(address => (
-          <AddressBox
-            key={address.addressId}
-            address={address}
-            onEditClick={() => this.handleStartEditing(address)}
-          />
-        ))}
+        {this.props.addresses.map(address => {
+          // Filter out temporarily addresses with addressType "pickup" because its also saved at Profile V2
+          if (address.addressType !== 'pickup') {
+            return (
+              <AddressBox
+                key={address.addressId}
+                address={address}
+                onEditClick={() => this.handleStartEditing(address)}
+              />
+            )
+          }
+
+          return null
+        })}
 
         {this.state.showToast && (
           <Toast


### PR DESCRIPTION
#### What did you change? \*

Add a filter to not show "pickup" AddressType at the my account.

Before:
<img width="1393" alt="image" src="https://github.com/vtex-apps/my-account/assets/67066494/84ef00e1-1d21-4cfc-b787-fb49e3a2fb78">


After:
<img width="1393" alt="image" src="https://github.com/vtex-apps/my-account/assets/67066494/0c09874b-af0f-45d3-beba-6f708fd77ffc">


#### Why? \*

This type of address should not be saved at the user profile  but different from Profile V1 the Profile V2 saves it so we are filtering by those in order to nor impact the User Experience. 


#### Types of changes \*

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical improvements
  <!--- * Required -->
