### PR TITLE
disable country when editing existing address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Disable country edition for addresses saved at the profile
+
 ## [1.27.1] - 2024-02-15
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.28.0] - 2024-07-09
+
 - Disable country edition for addresses saved at the profile
 
 ## [1.27.1] - 2024-02-15

--- a/manifest.json
+++ b/manifest.json
@@ -1,12 +1,10 @@
 {
   "name": "my-account",
   "vendor": "vtex",
-  "version": "1.27.1",
+  "version": "1.28.0",
   "title": "My Account",
   "description": "User's my account page.",
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "dependencies": {
     "vtex.my-cards": "1.x",
     "vtex.my-orders-app": "3.x",

--- a/react/components/Addresses/AddressForm.tsx
+++ b/react/components/Addresses/AddressForm.tsx
@@ -147,13 +147,27 @@ class AddressForm extends Component<InnerProps & OuterProps, State> {
 
   public render() {
     const { address } = this.state
-    const { intl, submitLabelId, isLoading, googleMapsApiKey, useGeolocation } =
-      this.props
+    const {
+      intl,
+      submitLabelId,
+      isLoading,
+      googleMapsApiKey,
+      useGeolocation,
+      isExistingAddress,
+    } = this.props
 
     const shipCountries = this.translateCountries()
     const hasGeoCoords = this.hasGeoCoords()
     const hasValidPostalCode = this.hasValidPostalCode()
     const hasAutoCompletedFields = this.hasAutoCompletedFields()
+
+    const enhancedAddress = {
+      ...address,
+      country: {
+        ...address.country,
+        disabled: !!isExistingAddress,
+      },
+    }
 
     return (
       <AddressRules
@@ -162,7 +176,7 @@ class AddressForm extends Component<InnerProps & OuterProps, State> {
         useGeolocation={useGeolocation}
       >
         <AddressContainer
-          address={address}
+          address={enhancedAddress}
           Input={StyleguideInput}
           onChangeAddress={this.handleAddressChange}
           autoCompletePostalCode
@@ -258,6 +272,7 @@ interface OuterProps {
   receiverName?: string
   onError: () => void
   onSubmit: (address: Address) => void
+  isExistingAddress?: boolean
 }
 
 type Props = InnerProps & OuterProps

--- a/react/components/pages/AddressEdit.tsx
+++ b/react/components/pages/AddressEdit.tsx
@@ -68,6 +68,7 @@ class AddressEdit extends Component<Props> {
           isLoading={isLoading}
           submitLabelId="vtex.store-messages@0.x::addresses.saveAddress"
           address={normalizedAddress}
+          isExistingAddress={!!addressId}
           onSubmit={this.handleSave}
           onError={this.props.handleError}
         />

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -70,6 +70,7 @@ declare global {
 
   interface AddressFormFields {
     [key: string]: {
+      disabled: boolean
       value: null | string | number | number[]
       valid?: boolean
       geolocationAutoCompleted?: boolean


### PR DESCRIPTION
#### What did you change? \*

When editing an existing address the user should not be able to edit the country of this address.

#### Why? \*

For profile V2 addresses schema we can not change the country of an existing address because the schema is different per country so we are disabling this option when editing an address to be compliant with this structure.

#### How to test it? \*

Test at this workspace: https://country--dunnesstoresqa.myvtex.com/account#/addresses
You may need to relink the version from this branch.

Before:

https://github.com/vtex-apps/my-account/assets/67066494/31eb65cb-ceae-4bac-b407-7974ffe82ca6

After:

https://github.com/vtex-apps/my-account/assets/67066494/ffbc12e3-68de-4fcb-a386-67b7504fd186


#### Types of changes \*

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical improvements
  <!--- * Required -->
