### PR TITLE
Add setting to show or hide authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- **authentication.showMyAuthentication** app setting.
+
 ## [1.29.0] - 2024-07-09
 
 ## [1.28.0] - 2024-07-09

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -9,4 +9,5 @@ type AppSettings {
   showMyCards: Boolean
   showMyOrders: Boolean
   showMyAddresses: Boolean
+  showMyAuthentication: Boolean
 }

--- a/manifest.json
+++ b/manifest.json
@@ -78,6 +78,17 @@
             "default": true
           }
         }
+      },
+      "authentication": {
+        "type": "object",
+        "title": "Authentication",
+        "properties": {
+          "showMyAuthentication": {
+            "type": "boolean",
+            "title": "Visible",
+            "default": true
+          }
+        }
       }
     }
   },

--- a/node/package.json
+++ b/node/package.json
@@ -22,7 +22,7 @@
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.138.0/public/@types/vtex.styleguide"
   },
   "dependencies": {
-    "@vtex/api": "6.46.1"
+    "@vtex/api": "6.48.0"
   },
   "version": "1.29.0"
 }

--- a/node/resolvers/settings.ts
+++ b/node/resolvers/settings.ts
@@ -17,6 +17,7 @@ async function settings(_: unknown, __: unknown, ctx: ServiceContext) {
     showMyCards: result.cards && result.cards.showMyCards,
     showMyOrders: result.orders && result.orders.showMyOrders,
     showMyAddresses: result.addresses && result.addresses.showMyAddresses,
+    showMyAuthentication: result.authentication && result.authentication.showMyAuthentication,
   }
 }
 
@@ -28,6 +29,7 @@ interface Settings {
   profile?: { showGenders: boolean }
   cards?: { showMyCards: boolean }
   orders?: { showMyOrders: boolean }
+  authentication?: { showMyAuthentication: boolean }
 }
 
 export default settings

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -210,10 +210,10 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-"@vtex/api@6.46.1":
-  version "6.46.1"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.46.1.tgz#55a8755ae48f5400e7f1ed1921cd547950bb7a2a"
-  integrity sha512-geoxVvyWoQpOQ70Zmx3M8SBkRoGOS/bp9Gy26M+iCue63jofVSwmFz1zf66EaHA1PKOJNRgQPFwY+oeDE1U2lQ==
+"@vtex/api@6.48.0":
+  version "6.48.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.48.0.tgz#67f9f11d197d543d4f854b057d31a8d6999241e9"
+  integrity sha512-mAdT7gbV0/BwiuqUkNH1E7KZqTUczT5NbBBZcPJq5kmTr73PUjbR9wh//70ryJo2EAdHlqIgqgwsCVpozenlhg==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -1857,7 +1857,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:

--- a/react/components/Menu/index.tsx
+++ b/react/components/Menu/index.tsx
@@ -20,11 +20,17 @@ interface RenderLinksOptions {
   showMyCards: boolean | null
   showMyOrders: boolean | null
   showMyAddresses: boolean | null
+  showMyAuthentication: boolean | null
 }
 
 function renderLinks(
   links: Link[],
-  { showMyCards, showMyOrders, showMyAddresses }: RenderLinksOptions
+  {
+    showMyCards,
+    showMyOrders,
+    showMyAddresses,
+    showMyAuthentication,
+  }: RenderLinksOptions
 ) {
   const linksToDisplay = links.filter(link => {
     if (showMyCards === false && link.path === '/cards') {
@@ -36,6 +42,10 @@ function renderLinks(
     }
 
     if (showMyAddresses === false && link.path === '/addresses') {
+      return false
+    }
+
+    if (showMyAuthentication === false && link.path === '/authentication') {
       return false
     }
 
@@ -60,6 +70,7 @@ class Menu extends Component<Props, { isModalOpen: boolean }> {
       showMyCards = false,
       showMyOrders = false,
       showMyAddresses = false,
+      showMyAuthentication = false,
     } = settings || {}
 
     return (
@@ -75,6 +86,7 @@ class Menu extends Component<Props, { isModalOpen: boolean }> {
                 showMyCards,
                 showMyOrders,
                 showMyAddresses,
+                showMyAuthentication,
               })
             }
           />

--- a/react/components/shared/withSettings.tsx
+++ b/react/components/shared/withSettings.tsx
@@ -25,5 +25,6 @@ export interface Settings {
   showMyCards: boolean | null
   showMyOrders: boolean | null
   showMyAddresses: boolean | null
+  showMyAuthentication: boolean | null
   useMap: boolean
 }

--- a/react/graphql/settings.gql
+++ b/react/graphql/settings.gql
@@ -5,6 +5,7 @@ query MyAccountSettings {
     showMyCards
     showMyOrders
     showMyAddresses
+    showMyAuthentication
     useMap
   }
 }


### PR DESCRIPTION
#### What did you change? \*

Added app setting to show or hide authentication in my account menu.

#### Why? \*

Stores using their own authentication need to be able to hide this option.

#### How to test it? \*

[Workspace Admin - My Account App Settings](https://ailbhevtexpr--colprofr.myvtex.com/admin/apps/vtex.my-account@1.29.0/setup)
Can see Authentication is unchecked in the app settings

[Workspace Site](https://ailbhevtexpr--colprofr.myvtex.com/)
Go to my account on the site, can see the authentication menu option is no longer visible


#### Types of changes \*

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical improvements
  <!--- * Required -->
