### PR TITLE
Update application ID in catalog-info.yaml

### DIFF
--- a/.vtex/catalog-info.yaml
+++ b/.vtex/catalog-info.yaml
@@ -12,7 +12,7 @@ metadata:
     github.com/project-slug: vtex-apps/my-account
     vtex.com/platform-flow-id: ""
     backstage.io/techdocs-ref: dir:../
-    vtex.com/application-id: JNMKHHLJ
+    vtex.com/application-id: ATMCJN60
 spec:
   lifecycle: stable
   owner: te-0020


### PR DESCRIPTION
This pull request updates the application ID in the `.vtex/catalog-info.yaml` file to ensure the metadata reflects the correct identifier.

* Changed the value of `vtex.com/application-id` from `JNMKHHLJ` to `ATMCJN60` in `.vtex/catalog-info.yaml` to update the application metadata.