### PR TITLE
Add aria-hidden attribute to UserPlaceholderPicture SVG

### DIFF
--- a/react/components/Menu/ProfilePicture/UserPlaceholderPicture.tsx
+++ b/react/components/Menu/ProfilePicture/UserPlaceholderPicture.tsx
@@ -9,6 +9,7 @@ const UserPlaceholderPicture = () => {
       viewBox="0 0 110 110"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
     >
       <rect width="110" height="110" fill="black" fillOpacity="0" />
       <rect width="110" height="110" fill="black" fillOpacity="0" />


### PR DESCRIPTION
#### What did you change? \*

Removed Profile Picture from accessibility tree.

#### Why?

To meet WCAG 2.1 standards, all decorative images should have `aria-hidden="true"` to prevent screen readers from reading them out.

#### How to test it? \*

Check that `aria-hidden="true"` has been added to the profile picture SVG on the account page.

[https://accessibility4--colproatqa.myvtex.com/](https://accessibility4--colproatqa.myvtex.com/)

#### Types of changes \*

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical improvements
  <!--- * Required -->
