### PR TITLE
Update catalog-info.yaml

### DIFF
--- a/.vtex/catalog-info.yaml
+++ b/.vtex/catalog-info.yaml
@@ -13,6 +13,7 @@ metadata:
     vtex.com/platform-flow-id: ""
     backstage.io/techdocs-ref: dir:../
     vtex.com/application-id: ATMCJN60
+    vtex.com/platform-flow-id: Merch#6
 spec:
   lifecycle: stable
   owner: te-0020


### PR DESCRIPTION
This pull request makes a small update to the `.vtex/catalog-info.yaml` file, specifically updating the `vtex.com/platform-flow-id` metadata field to "Merch#6". This helps ensure the catalog metadata reflects the correct platform flow association.