### PR TITLE
feat: allow custom layout via children composition and JSX menu links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Support for `children` composition in the `my-account` block. When children are provided, they fully replace the default `<Menu />` + `<AppRouter />` layout, allowing stores to render a completely custom my-account experience while still satisfying the `vtex.store@2.x:store.account` interface requirement. When no children are passed, the default layout renders as before — fully backwards compatible.
+- `my-account-menu` plugins can now return React elements directly inside the array passed to `render`, in addition to the existing `{ name, path }` object shape. This lets stores fully customize the visual appearance of sidebar links (icons, typography, hover states, etc.) without replacing the entire menu. Plugins that continue to pass `{ name, path }` objects keep rendering with the default `MenuLink` component — backwards compatible.
+
 ## [1.30.2] - 2026-04-10
 
 ## [1.30.1] - 2026-02-27

--- a/docs/README.md
+++ b/docs/README.md
@@ -151,9 +151,14 @@ In this example you will have two new pages `/account/#/support` and `/account/#
 
 #### Creating a `my-account-link` component
 
-This component will receive a prop called `render`. You **must** call it with an array of objects with the properties `name` and `path`. This will create the link given the `name` and the `path` provided.
+This component will receive a prop called `render`. You **must** call it with an array of items. Each item can be either:
 
-Example of an MyAppLink implementation:
+1. An object with `name` and `path` properties — the default menu link style will be applied.
+2. A React element — it will be rendered as-is, allowing full visual customization.
+
+You can mix both shapes in the same array.
+
+**Example 1: default style (backwards compatible)**
 
 ```jsx
 import PropTypes from 'prop-types'
@@ -179,6 +184,44 @@ MyAppLink.propTypes = {
 
 export default injectIntl(MyAppLink)
 ```
+
+**Example 2: fully styled link (since v1.31.0)**
+
+```jsx
+import React from 'react'
+import { Link } from 'vtex.render-runtime'
+
+const HeartIcon = () => (
+  <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+    {/* ... */}
+  </svg>
+)
+
+const StyledLink = ({ href, children }) => (
+  <Link
+    to={href}
+    className="flex items-center gap-2 py-3 text-sm hover-opacity-70"
+    style={{ color: '#0B0D0D' }}
+  >
+    <HeartIcon />
+    {children}
+  </Link>
+)
+
+const MyAppLink = ({ render }) => {
+  return render([
+    <StyledLink key="favorites" href="/wishlist">
+      Favoritos
+    </StyledLink>,
+  ])
+}
+
+export default MyAppLink
+```
+
+In Example 2, the `my-account` menu will render your `<StyledLink>` as-is, without wrapping it in the default `MenuLink` component. You can apply your own typography, colors, icons, and hover states freely.
+
+The `showMyCards`, `showMyOrders`, `showMyAddresses`, and `showMyAuthentication` app settings still filter default links (by `path` match), but they do **not** apply to custom React elements — your plugin is responsible for filtering them if needed.
 
 ### Defining the default home page of My Account
 
@@ -276,6 +319,64 @@ class FavColor extends Component {
 
 export default FavColor
 ```
+
+### Fully replacing the my-account layout
+
+The extension points above are the preferred way to customize My Account in most cases, since they preserve the default shell (menu, routing, breadcrumbs) while letting you add or tweak individual pieces.
+
+However, some stores need a **completely custom my-account experience** — different menu, different routing, different typography, rendered inside a fully branded shell. Until now, that required either forking this app or working around the `vtex.store@2.x:store.account` interface requirement (which mandates that `store.account` contains a block implementing `vtex.my-account@1.x:my-account`).
+
+Starting from version `1.31.0`, the `my-account` block supports `children` composition. When children are provided, they **fully replace** the default `<Menu />` + `<AppRouter />` layout, while still satisfying the interface requirement so the builder doesn't error out.
+
+**When no children are passed, the default layout renders as before — this change is fully backwards compatible.**
+
+#### Usage
+
+In your store-theme, declare a custom block that implements your layout and pass it as a child of `my-account`:
+
+```jsonc
+// store/interfaces.json
+{
+  "my-custom-account": {
+    "component": "MyCustomAccount"
+  }
+}
+```
+
+```jsonc
+// store/blocks.jsonc
+{
+  "store.account": {
+    "blocks": ["my-account"],
+    "parent": {
+      "challenge": "challenge.profile"
+    }
+  },
+
+  "my-account": {
+    "children": ["my-custom-account"]
+  }
+}
+```
+
+```tsx
+// react/MyCustomAccount.tsx
+import React from 'react'
+
+const MyCustomAccount: React.FC = () => {
+  return (
+    <div className="my-custom-account">
+      {/* your fully custom layout: sidebar, routing, pages, etc. */}
+    </div>
+  )
+}
+
+export default MyCustomAccount
+```
+
+Accessing `/account` will now render `MyCustomAccount` inside `MyAccountWrapper` (which still takes care of the default pixel tracking), bypassing the built-in menu, hash router, and all default pages.
+
+You are responsible for implementing your own navigation, routing (if any), and data fetching inside the custom component. The `my-account-pages`, `my-account-menu`, `profile-display-container`, and `profile-input-container` extension points are **not** rendered when children are used — if you need plugin support in your custom layout, you can still use `<ExtensionPoint id="..." />` from `vtex.render-runtime` inside your component.
 
 ## Author
 

--- a/react/components/Menu/index.tsx
+++ b/react/components/Menu/index.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 /* eslint-disable jsx-a11y/no-static-element-interactions */
-import React, { Component, Fragment } from 'react'
+import type { ReactNode } from 'react'
+import React, { Component, Fragment, isValidElement } from 'react'
 import type { InjectedIntlProps } from 'react-intl'
 import { injectIntl, FormattedMessage } from 'react-intl'
 import { compose } from 'recompose'
@@ -23,8 +24,12 @@ interface RenderLinksOptions {
   showMyAuthentication: boolean | null
 }
 
+function isReactLink(link: Link | ReactNode): link is ReactNode {
+  return isValidElement(link)
+}
+
 function renderLinks(
-  links: Link[],
+  links: Array<Link | ReactNode>,
   {
     showMyCards,
     showMyOrders,
@@ -33,28 +38,39 @@ function renderLinks(
   }: RenderLinksOptions
 ) {
   const linksToDisplay = links.filter(link => {
-    if (showMyCards === false && link.path === '/cards') {
+    if (isReactLink(link)) return true
+
+    const typed = link as Link
+
+    if (showMyCards === false && typed.path === '/cards') {
       return false
     }
 
-    if (showMyOrders === false && link.path === '/orders') {
+    if (showMyOrders === false && typed.path === '/orders') {
       return false
     }
 
-    if (showMyAddresses === false && link.path === '/addresses') {
+    if (showMyAddresses === false && typed.path === '/addresses') {
       return false
     }
 
-    if (showMyAuthentication === false && link.path === '/authentication') {
+    if (showMyAuthentication === false && typed.path === '/authentication') {
       return false
     }
 
     return true
   })
 
-  return linksToDisplay.map(({ name, path }) => (
-    <MenuLink path={path} name={name} key={name} />
-  ))
+  return linksToDisplay.map((link, index) => {
+    if (isReactLink(link)) {
+      const element = link as React.ReactElement
+      const key = element.key != null ? element.key : `custom-link-${index}`
+      return React.cloneElement(element, { key })
+    }
+
+    const { name, path } = link as Link
+    return <MenuLink path={path} name={name} key={name} />
+  })
 }
 
 class Menu extends Component<Props, { isModalOpen: boolean }> {
@@ -81,7 +97,7 @@ class Menu extends Component<Props, { isModalOpen: boolean }> {
         <nav className={cssHandles.menuLinks}>
           <ExtensionPoint
             id="my-account-menu"
-            render={(links: Link[]) =>
+            render={(links: Array<Link | ReactNode>) =>
               renderLinks(links, {
                 showMyCards,
                 showMyOrders,

--- a/react/components/MyAccountWrapper.tsx
+++ b/react/components/MyAccountWrapper.tsx
@@ -1,11 +1,11 @@
 /* eslint-disable no-restricted-globals */
-import type { FunctionComponent, ReactElement } from 'react'
-import { useMemo } from 'react'
+import type { FunctionComponent, ReactNode } from 'react'
+import React, { useMemo } from 'react'
 import { useRuntime } from 'vtex.render-runtime'
 
 import useDataPixel from '../hooks/useDataPixel'
 
-const MyAccountWrapper: FunctionComponent<{ children: ReactElement }> = ({
+const MyAccountWrapper: FunctionComponent<{ children: ReactNode }> = ({
   children,
 }) => {
   const { account } = useRuntime()
@@ -39,7 +39,7 @@ const MyAccountWrapper: FunctionComponent<{ children: ReactElement }> = ({
 
   useDataPixel(pixelEvents, 'MyAccount')
 
-  return children
+  return <>{children}</>
 }
 
 export default MyAccountWrapper

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -1,4 +1,5 @@
-import React, { Component } from 'react'
+import type { ReactNode } from 'react'
+import React, { Children, Component } from 'react'
 import 'vtex.country-codes/locales'
 
 import AppRouter from './components/AppRouter'
@@ -7,6 +8,7 @@ import { logGeneralErrors } from './utils/logger'
 
 interface Props {
   blockDocument?: boolean
+  children?: ReactNode
 }
 
 class MyAccount extends Component<Props> {
@@ -17,11 +19,18 @@ class MyAccount extends Component<Props> {
   }
 
   public render() {
+    const { children, blockDocument } = this.props
+    const hasChildren = Children.count(children) > 0
+
     return (
       <Wrapper>
-        <div className="vtex-account helvetica flex justify-around">
-          <AppRouter blockDocument={this.props.blockDocument} />
-        </div>
+        {hasChildren ? (
+          children
+        ) : (
+          <div className="vtex-account helvetica flex justify-around">
+            <AppRouter blockDocument={blockDocument} />
+          </div>
+        )}
       </Wrapper>
     )
   }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -1,6 +1,7 @@
 {
   "my-account": {
     "component": "index",
+    "composition": "children",
     "required": [
       "my-account-pages",
       "my-account-defaultPage",


### PR DESCRIPTION
## Summary

Two backwards-compatible extension points for stores that need deeper customization of the my-account experience. Both features are opt-in and the default layout renders identically when neither is used.

## Motivation

Today, stores that want a fully branded my-account experience have limited options:

- The `my-account-pages` / `my-account-menu` plugin system lets you add new pages and links, but not replace the overall shell (`<Menu />` + `<AppRouter />`).
- Forking this app just to swap out the layout is overkill and creates maintenance burden.
- Going around `store.account` with a `store.custom` route works, but leaves the `/account` URL pointing at the default layout (or at a dead page), and the `vtex.store@2.x:store.account` interface still requires a block implementing `vtex.my-account@1.x:my-account`.

This PR adds two small, fully backwards-compatible extension points that close these gaps.

## Changes

### 1. `children` composition on the `my-account` block

When children are provided, they fully replace the default `<Menu />` + `<AppRouter />` layout. Usage in a store-theme:

```jsonc
// store/blocks.jsonc
{
  "store.account": {
    "blocks": ["my-account"]
  },
  "my-account": {
    "children": ["my-custom-account"]
  }
}
```
When no children are passed, the existing layout renders exactly as before. See [docs/README.md](vscode-webview://0tihprdqbg94ie15aje2f5a6du4vlji0b2t9pm4mrqmve95g0u8d/docs/README.md#fully-replacing-the-my-account-layout) for a complete example.

Files changed:

```jsonc
    react/index.tsx — accepts a children?: ReactNode prop, falls back to the default layout when not present.
    react/components/MyAccountWrapper.tsx — relaxes the children type from ReactElement to ReactNode and returns a fragment.
    store/interfaces.json — adds "composition": "children" to the my-account block.
```
### 2. my-account-menu plugins can return React elements
Plugins registered under my-account-menu > my-account-link can now pass React elements directly inside the array given to render, in addition to the existing { name, path } object shape:


```js
  const MyAppLink = ({ render }) => render([
    <StyledLink key="favorites" href="/wishlist" icon={<HeartIcon />}>
      Favoritos
    </StyledLink>,
  ])
```
Plugins that continue to pass { name, path } objects keep rendering with the default MenuLink component — no change to existing behavior.

The showMyCards / showMyOrders / showMyAddresses / showMyAuthentication app settings still filter default { name, path } links by path. They do not apply to React element links — plugins are responsible for their own filtering when needed.

## Files changed:

react/components/Menu/index.tsx — adds an isReactLink type guard and renders React elements as-is via React.cloneElement.
Backwards compatibility
Both features are opt-in. Stores that don't use them render identically to before:

Children.count(children) > 0 returns 0 when no children are passed, falling back to the exact default JSX.
isValidElement(link) returns false for plain { name, path } objects, falling back to the existing <MenuLink /> rendering.
No changes to existing prop types, no breaking changes to plugins, no changes to extension point contracts (my-account-pages, my-account-menu, profile-display-container, profile-input-container all continue to work as before).

TypeScript typecheck passes (yarn tsc --noEmit in react/).

## Test plan

 Default layout still renders when no children are passed and no custom JSX links are used.
 Custom layout renders when children are provided in the store's block tree.
 A custom React element returned by a plugin is rendered in place of the default MenuLink.
 A plugin returning the legacy { name, path } shape still renders with the default MenuLink.
 The four showMy* settings still filter legacy links by path.
 yarn tsc --noEmit passes in react/.